### PR TITLE
Add OSS metadata and contribution docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+# Bug Report
+
+## What happened?
+
+Describe the problem.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected result
+
+What should have happened?
+
+## Actual result
+
+What happened instead?
+
+## Environment
+
+- OS:
+- Android Studio version:
+- JDK version:
+- Device or emulator:
+
+## Logs or screenshots
+
+Paste logs or screenshots if available.

--- a/.github/ISSUE_TEMPLATE/migration_task.md
+++ b/.github/ISSUE_TEMPLATE/migration_task.md
@@ -1,0 +1,17 @@
+# Migration Task
+
+## Goal
+
+What migration step does this issue cover?
+
+## Tasks
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Done when
+
+- [ ] Code is updated
+- [ ] Tests pass
+- [ ] Documentation is updated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,9 @@ Explain what changed.
 - [ ] I ran `./gradlew test`
 - [ ] I ran `./gradlew assembleDebug`
 - [ ] I checked the app manually
+- [ ] Not applicable: docs-only change
 
 ## Notes
 
-Write any failure reason, known issue, or follow-up task here.
+- If any test/build command is not run, explain why.
+- Write any failure reason, known issue, or follow-up task here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+Explain what changed.
+
+## Migration step
+
+- [ ] Documentation
+- [ ] Build / Gradle
+- [ ] Domain model
+- [ ] Reducer
+- [ ] ViewModel
+- [ ] Compose UI
+- [ ] Tests
+- [ ] CI
+
+## How I tested this
+
+- [ ] I ran `./gradlew test`
+- [ ] I ran `./gradlew assembleDebug`
+- [ ] I checked the app manually
+
+## Notes
+
+Write any failure reason, known issue, or follow-up task here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## v0.1.0-oss-alpha.1
+## Unreleased
 
 ### Added
-- Modern Kotlin + Compose app baseline
-- Article shared-state project goal and identity cleanup
-- Preserve legacy 2017 snapshot and archive marker
-- Beginner-oriented migration documentation references
-
-### Preserved
-- Original 2017 Android AAC ViewModel sample as legacy archive
+- Rewrote README for OSS migration lab direction and status
+- Added OSS metadata files
+- Added GitHub pull request and issue templates
+- Preserved original README in docs as legacy architecture archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## v0.1.0-oss-alpha.1
+
+### Added
+- Modern Kotlin + Compose app baseline
+- Article shared-state project goal and identity cleanup
+- Preserve legacy 2017 snapshot and archive marker
+- Beginner-oriented migration documentation references
+
+### Preserved
+- Original 2017 Android AAC ViewModel sample as legacy archive

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+This project is intended to be a friendly learning space.
+
+Please be respectful, patient, and constructive when opening issues, reviewing pull requests, or asking questions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+Thank you for your interest in contributing.
+
+This project is a beginner-friendly migration lab for legacy Android architecture.
+
+## How to contribute
+
+1. Pick a small issue.
+2. Create a small branch.
+3. Make one focused change.
+4. Run tests when applicable.
+5. Open a pull request.
+
+## Rules
+
+- Keep each pull request small.
+- Do not mix unrelated changes.
+- Prefer readable code over clever code.
+- Update documentation when behavior changes.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution.
+
+      You may reproduce and distribute copies of the Work or
+      Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work, excluding
+          those notices that do not pertain to any part of the Derivative
+          Works, and include the following notice: "This product includes
+          software developed at OpenAI." in a file with this Attribution Notice
+          if the product includes software from the Licensor.
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works, within the Source form or
+          documentation, or, within a display generated by the Derivative
+          Works, if and wherever such third-party notices normally appear.
+          The contents of the NOTICE file are for informational purposes
+          only and do not modify the License. You may add your own
+          attribution notices within Derivative Works that You distribute,
+          alongside or as an addendum to the NOTICE text from the Work,
+          provided that such additional attribution notices cannot be
+          construed as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications,
+      or for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only on
+      Your own behalf and on Your sole responsibility, not on behalf of
+      any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The future modern version will provide:
 ## Migration docs
 
 - [2017 Legacy Architecture](docs/01-legacy-architecture.md)
+- [Migration Task Plan (source of truth)](docs/oss-remake-task-plan.md)
+- [Historical planning references](docs/planning/archive/oss-remake-plan-reference.md)
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,30 @@
 
 A beginner-friendly OSS migration lab that modernizes a 2017 Android AAC ViewModel shared-state sample with Kotlin, Compose, ViewModel, and StateFlow.
 
-## What this project teaches
+This repository is in the **OSS setup phase** of the migration.
+
+## Current status
+
+Completed in this phase:
+
+- Project direction clarified as `Android ViewModel Migration Lab`
+- Legacy README preserved as historical documentation
+- OSS metadata files added (`LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.md`)
+- GitHub issue/PR templates added
+
+Not yet implemented:
+
+- Modern Kotlin + Compose app baseline
+- Article domain/model layer
+- Reducer and ViewModel implementation
+- Compose list/detail UI screens
+- Unit tests and Android CI
+
+## What this project will teach
 
 - How to keep shared state synchronized across multiple screens
 - How to migrate legacy Android Architecture Components patterns to modern Kotlin/Compose architecture
-- How to structure tests for reducer and ViewModel logic
+- How to structure reducer and ViewModel tests
 
 ## Original problem
 
@@ -15,9 +34,9 @@ The original project shared an `Article` model between screens:
 - Detail screen edits a selected Article
 - Save should update the list state immediately
 
-## Modern solution
+## Planned modern solution
 
-This repository preserves the original idea but provides a modern baseline using:
+The future modern version will provide:
 - Kotlin + Compose UI
 - ViewModel
 - StateFlow
@@ -26,19 +45,13 @@ This repository preserves the original idea but provides a modern baseline using
 ## Quick start
 
 1. Clone the repository
-2. Build with Gradle
-
-```bash
-./gradlew test
-./gradlew assembleDebug
-```
+2. Work in sequence with the migration PRs in this repository
 
 ## Project structure
 
-- `README.md`: project purpose and usage
-- `app/`: modern Kotlin/Compose sample app
-- `docs/`: migration notes and guides
-- `.github/`: issue/pr templates and CI config
+- `README.md`: project purpose and progress
+- `docs/`: migration notes and legacy baseline records
+- `.github/`: pull request and issue templates
 
 ## Migration docs
 
@@ -49,10 +62,12 @@ This repository preserves the original idea but provides a modern baseline using
 - [x] Preserve legacy baseline as archive
 - [x] Preserve legacy 2017 snapshot (`legacy/2017-original`, `v0.0.0-legacy-2017`)
 - [ ] Add modern app baseline
-- [ ] Add Article domain/model and reducer tests
-- [ ] Add ViewModel tests
+- [ ] Add Article domain/model and reducer
+- [ ] Add ArticleListReducer tests
+- [ ] Add ViewModel + StateFlow implementation
 - [ ] Add Compose screens
-- [ ] Add CI workflow
+- [ ] Add unit tests
+- [ ] Add Android CI workflow
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,63 @@
-### Demo
-![](http://cfile24.uf.tistory.com/image/23332E3C592E268C34689B)
+# Android ViewModel Migration Lab
 
+A beginner-friendly OSS migration lab that modernizes a 2017 Android AAC ViewModel shared-state sample with Kotlin, Compose, ViewModel, and StateFlow.
 
-### Branch
-basic-livedata-viewmodel > Use LiveData, ViewModel.  
-dagger > Use LiveData, ViewModel, Dagger2.  
-dagger-databinding -> Use LiveData, ViewModel, Dagger2, DataBinding.
+## What this project teaches
 
-### purpose
+- How to keep shared state synchronized across multiple screens
+- How to migrate legacy Android Architecture Components patterns to modern Kotlin/Compose architecture
+- How to structure tests for reducer and ViewModel logic
 
-If you use a same model in each screen, I want to synchronize all the model and manage and update same views.
-Before using LiveData and ViewModel, I had to update the View in the background through RxBus.
-The problem was that the more screens using the same model, the more difficult it was to maintain.
+## Original problem
 
-This practice project has made one and the same model shared by two fragments. 
-There is an ArticleListFragment, go to ArticleDetailFragment when you click Item in Article List. 
-The ArticleDetailFragment can modify the Article and save, 
-the UI of the ArticleListFragment in the background is also updated to the latest state.
+The original project shared an `Article` model between screens:
+- List screen shows Articles
+- Detail screen edits a selected Article
+- Save should update the list state immediately
 
-### Using Single Activity Pattern
-Since ViewModel can be created in Activity unit, 
-it is difficult to share ViewModel between different activities. 
-Single Activity Pattern is used and all screens are configured as Fragment.
+## Modern solution
 
-### 目的
-各画面で共通のモデルを使う場合、データを全て同期したViewとして管理するためです。
-LiveDataとViewModelを使う以前には、RxBusなどを使ってBackgroundのViewを更新しました。
-Backgroundのリストのデータを更新するためには変更されたItemをリスト検索を通じて探した後更新する。
-同じモデルを使う画面が増えるほどメンテナンスが難しい問題がありました。
+This repository preserves the original idea but provides a modern baseline using:
+- Kotlin + Compose UI
+- ViewModel
+- StateFlow
+- Reducer-style state updates
 
-このpractice projectは一つのモデルを二つのFragmentで共有するように作られました。
-ArticleListFragment가があって、Article ListのItemをクリックする場合、ArticleDetailFragmentに遷移します。
-ArticleDetailFragmentではArticleを修正することが可能で、保存する場合、BackgroundにあるArticleListFragmentのUiも最新状態に更新されます。
+## Quick start
 
-### Single Activity Pattern使用
-ViewModelの場合、Activity単位で生成することが可能で、違うActivity間のViewModelの共有は難しいと判断し
-Single Activity Patternを利用して全ての画面をFragmentで構成しました。
+1. Clone the repository
+2. Build with Gradle
 
-### 목적
-각 화면에서 공통의 모델을 사용하는경우 데이터를 모두 동기화하여 동일한 View로 관리하기 위해서입니다.  
-LiveData 및 ViewModel을 사용하기 전에는 RxBus를 통해서 백그라운드의 View를 갱신하였었습니다.  
-백그라운드의 리스트의 데이터를 갱신하기 위해서는 변경된 Item을 리스트 검색을 통하여 찾은 후 갱신해야 하는 것.  
-동일한 모델을 사용하는 화면이 많아질수록 유지보수 하기가 어려워진다는 문제가 있었습니다.
+```bash
+./gradlew test
+./gradlew assembleDebug
+```
 
-이 연습 프로젝트는 하나의 동일한 모델을 두개의 프라그먼트에서 공유하여 사용하도록 만들었습니다.
-ArticleListFragment가 있으며, Article List의 Item을 클릭할 경우 ArticleDetailFragment로 이동합니다.
-ArticleDetailFragment에서는 Article을 수정할 수 있으며 저장할 경우 백그라운드에 있는 ArticleListFragment의 UI도 최신 상태로 갱신됩니다.
+## Project structure
 
-### Single Activity Pattern 사용
-ViewModel의 경우 Activity 단위로 생성하는것이 가능하므로 서로 다른 Activity간의 ViewModel을 공유하는것은 어렵다고 판단하여
-Single Activity Pattern을 사용하며 모든 화면을 Fragment로 구성하였습니다.
+- `README.md`: project purpose and usage
+- `app/`: modern Kotlin/Compose sample app
+- `docs/`: migration notes and guides
+- `.github/`: issue/pr templates and CI config
+
+## Migration docs
+
+- [2017 Legacy Architecture](docs/01-legacy-architecture.md)
+
+## Roadmap
+
+- [x] Preserve legacy baseline as archive
+- [x] Preserve legacy 2017 snapshot (`legacy/2017-original`, `v0.0.0-legacy-2017`)
+- [ ] Add modern app baseline
+- [ ] Add Article domain/model and reducer tests
+- [ ] Add ViewModel tests
+- [ ] Add Compose screens
+- [ ] Add CI workflow
+
+## Contributing
+
+Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) and add small, focused changes.
+
+## License
+
+Apache-2.0. See [`LICENSE`](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+This project is an educational Android migration sample.
+
+If you find a security issue in sample code or documentation, please open an issue with a clear explanation and reproduction steps.
+
+Do not include secrets, API keys, private credentials, or personal data in issues or pull requests.

--- a/docs/01-legacy-architecture.md
+++ b/docs/01-legacy-architecture.md
@@ -1,3 +1,7 @@
+> This document preserves the original README and legacy architecture notes.
+> It describes the 2017-era sample and may reference old Android tooling.
+> The modern migration documentation will be added from the next doc set (for example, `docs/02-modern-architecture.md`).
+
 # 2017 Legacy Architecture
 
 ### Demo
@@ -29,19 +33,19 @@ Single Activity Pattern is used and all screens are configured as Fragment.
 各画面で共通のモデルを使う場合、データを全て同期したViewとして管理するためです。
 LiveDataとViewModelを使う以前には、RxBusなどを使ってBackgroundのViewを更新しました。
 Backgroundのリストのデータを更新するためには変更されたItemをリスト検索を通じて探した後更新する。
-同じモデルを使う画面が増えるほどメンテナンスが難しい問題がありました。
+同じモデルを使う画面が増えるほどメン테ナンスが難しい問題がありました。
 
 このpractice projectは一つのモデルを二つのFragmentで共有するように作られました。
-ArticleListFragment가があって、Article ListのItemをクリックする場合、ArticleDetailFragmentに遷移します。
+ArticleListFragment가가あって、Article ListのItemをクリックする場合、ArticleDetailFragmentに遷移します。
 ArticleDetailFragmentではArticleを修正することが可能で、保存する場合、BackgroundにあるArticleListFragmentのUiも最新状態に更新されます。
 
 ### Single Activity Pattern使用
-ViewModelの場合、Activity単位で生成することが可能で、違うActivity間のViewModelの共有は難しいと判断し
+ViewModelの場合、Activity単位で生成することが可能で、違うActivity間のViewModelを共有することは難しいと判断し
 Single Activity Patternを利用して全ての画面をFragmentで構成しました。
 
 ### 목적
 각 화면에서 공통의 모델을 사용하는경우 데이터를 모두 동기화하여 동일한 View로 관리하기 위해서입니다.  
-LiveData 및 ViewModel을 사용하기 전에는 RxBus를 통해서 백그라운드의 View를 갱신하였었습니다.  
+LiveData 및 ViewModel을 사용하기 전에는 RxBus를 통해서 백그라운드의 View를 갱신하였습니다.  
 백그라운드의 리스트의 데이터를 갱신하기 위해서는 변경된 Item을 리스트 검색을 통하여 찾은 후 갱신해야 하는 것.  
 동일한 모델을 사용하는 화면이 많아질수록 유지보수 하기가 어려워진다는 문제가 있었습니다.
 

--- a/docs/01-legacy-architecture.md
+++ b/docs/01-legacy-architecture.md
@@ -1,0 +1,54 @@
+# 2017 Legacy Architecture
+
+### Demo
+![](http://cfile24.uf.tistory.com/image/23332E3C592E268C34689B)
+
+
+### Branch
+basic-livedata-viewmodel > Use LiveData, ViewModel.  
+dagger > Use LiveData, ViewModel, Dagger2.  
+dagger-databinding -> Use LiveData, ViewModel, Dagger2, DataBinding.
+
+### purpose
+
+If you use a same model in each screen, I want to synchronize all the model and manage and update same views.
+Before using LiveData and ViewModel, I had to update the View in the background through RxBus.
+The problem was that the more screens using the same model, the more difficult it was to maintain.
+
+This practice project has made one and the same model shared by two fragments. 
+There is an ArticleListFragment, go to ArticleDetailFragment when you click Item in Article List. 
+The ArticleDetailFragment can modify the Article and save, 
+the UI of the ArticleListFragment in the background is also updated to the latest state.
+
+### Using Single Activity Pattern
+Since ViewModel can be created in Activity unit, 
+it is difficult to share ViewModel between different activities. 
+Single Activity Pattern is used and all screens are configured as Fragment.
+
+### 目的
+各画面で共通のモデルを使う場合、データを全て同期したViewとして管理するためです。
+LiveDataとViewModelを使う以前には、RxBusなどを使ってBackgroundのViewを更新しました。
+Backgroundのリストのデータを更新するためには変更されたItemをリスト検索を通じて探した後更新する。
+同じモデルを使う画面が増えるほどメンテナンスが難しい問題がありました。
+
+このpractice projectは一つのモデルを二つのFragmentで共有するように作られました。
+ArticleListFragment가があって、Article ListのItemをクリックする場合、ArticleDetailFragmentに遷移します。
+ArticleDetailFragmentではArticleを修正することが可能で、保存する場合、BackgroundにあるArticleListFragmentのUiも最新状態に更新されます。
+
+### Single Activity Pattern使用
+ViewModelの場合、Activity単位で生成することが可能で、違うActivity間のViewModelの共有は難しいと判断し
+Single Activity Patternを利用して全ての画面をFragmentで構成しました。
+
+### 목적
+각 화면에서 공통의 모델을 사용하는경우 데이터를 모두 동기화하여 동일한 View로 관리하기 위해서입니다.  
+LiveData 및 ViewModel을 사용하기 전에는 RxBus를 통해서 백그라운드의 View를 갱신하였었습니다.  
+백그라운드의 리스트의 데이터를 갱신하기 위해서는 변경된 Item을 리스트 검색을 통하여 찾은 후 갱신해야 하는 것.  
+동일한 모델을 사용하는 화면이 많아질수록 유지보수 하기가 어려워진다는 문제가 있었습니다.
+
+이 연습 프로젝트는 하나의 동일한 모델을 두개의 프라그먼트에서 공유하여 사용하도록 만들었습니다.
+ArticleListFragment가 있으며, Article List의 Item을 클릭할 경우 ArticleDetailFragment로 이동합니다.
+ArticleDetailFragment에서는 Article을 수정할 수 있으며 저장할 경우 백그라운드에 있는 ArticleListFragment의 UI도 최신 상태로 갱신됩니다.
+
+### Single Activity Pattern 사용
+ViewModel의 경우 Activity 단위로 생성하는것이 가능하므로 서로 다른 Activity간의 ViewModel을 공유하는것은 어렵다고 판단하여
+Single Activity Pattern을 사용하며 모든 화면을 Fragment로 구성하였습니다.

--- a/docs/oss-pr3-review-notes.md
+++ b/docs/oss-pr3-review-notes.md
@@ -1,0 +1,351 @@
+# PR #3 리뷰: `Add OSS metadata and contribution docs`
+
+## 결론
+
+**방향은 좋습니다. 첫 PR로 적절합니다.**
+다만 **README/CHANGELOG/PR 설명에서 “이미 구현된 것”과 “앞으로 할 것”을 명확히 분리**하면 더 안전합니다.
+
+제가 보는 머지 판단은:
+
+> **조건부 Approve**
+> 아래 3가지만 확인/수정하면 머지해도 됩니다.
+
+1. README가 아직 존재하지 않는 `Compose / StateFlow / CI / modern app`을 **완료된 것처럼 말하지 않는지** 확인
+2. `CHANGELOG.md`가 `v0.1.0`을 이미 릴리스된 것처럼 쓰지 않고 `Unreleased` 중심인지 확인
+3. PR 본문에 “문서/메타데이터 전용 PR이라 Gradle build/test는 아직 대상 아님”을 명시
+
+PR 본문 기준으로는 README 재작성, OSS 메타 파일 추가, `.github` 템플릿 추가, 기존 baseline 문서 보존을 포함하고 있어서, 우리가 정한 **0단계 원본 보존 + 1단계 OSS 메타/가이드 기본 구성**과 잘 맞습니다. PR 설명에도 “beginner-friendly OSS migration lab”으로 설정하고, README/라이선스/CONTRIBUTING/SECURITY/CODE_OF_CONDUCT/CHANGELOG 및 `.github` 템플릿을 추가했다고 되어 있습니다. 
+
+---
+
+# 전체 평가
+
+| 항목         | 평가     |
+| ---------- | ------ |
+| PR 크기      | 적절함    |
+| 첫 PR로서의 역할 | 좋음     |
+| 프로젝트 방향성   | 계획과 일치 |
+| 코드 리스크     | 낮음     |
+| 문서 리스크     | 약간 있음  |
+| 머지 가능성     | 조건부 가능 |
+
+이번 PR은 실제 앱 코드 변경이 아니라 **저장소의 정체성을 정리하는 PR**입니다. 그래서 첫 PR로 매우 좋습니다.
+
+우리가 수정본 계획에서 정한 방향은 `Article` 중심의 레거시 Android AAC/ViewModel 공유 상태 샘플을 현대 Android로 재구성하는 것이고, Reserve.M/예약/매출/ダブルブッキング 같은 비즈니스 용어는 제거하는 것이었습니다. 
+PR 제목과 설명을 보면 현재 PR은 그 방향에 맞게 “Android ViewModel Migration Lab”으로 저장소의 방향을 잡는 역할을 하고 있습니다. 
+
+---
+
+# 좋은 점
+
+## 1. 첫 PR 범위가 적절합니다
+
+첫 PR에서 바로 Gradle, Kotlin, Compose, ViewModel까지 건드리지 않은 점이 좋습니다.
+
+이번 PR은 다음에 해당합니다.
+
+```text
+README 정리
+OSS 메타 문서 추가
+PR/Issue 템플릿 추가
+기존 README/baseline 문서 보존
+작업 계획 문서 추가
+```
+
+이건 우리가 정한 실행 순서의 초반부와 맞습니다.
+
+```text
+1. 원본 보존
+2. OSS 메타 문서 정비
+3. 현대 앱 뼈대 정비
+4. Article 모델/Reducer
+...
+```
+
+수정본 계획서도 먼저 원본 보존과 OSS 메타 문서 정비를 하도록 되어 있습니다. 
+
+## 2. “다음 PR의 범위”를 남긴 점이 좋습니다
+
+PR 본문에 “Next PRs will add modern Kotlin/Compose app baseline and tests”라고 되어 있는 방향은 좋습니다. 즉, 이번 PR이 **완성 PR이 아니라 시작 PR**이라는 점을 분명히 하려는 의도가 보입니다. 
+
+이건 매우 중요합니다. 첫 PR은 저장소 방향을 고정하는 역할만 하고, 실제 구현은 다음 PR로 나누는 게 맞습니다.
+
+## 3. OSS 제출용 기본 골격이 생깁니다
+
+이번 PR에서 추가한 것으로 보이는 파일들은 모두 필요합니다.
+
+```text
+README.md
+LICENSE
+CONTRIBUTING.md
+SECURITY.md
+CODE_OF_CONDUCT.md
+CHANGELOG.md
+.github/pull_request_template.md
+.github/ISSUE_TEMPLATE/bug_report.md
+.github/ISSUE_TEMPLATE/migration_task.md
+docs/01-legacy-architecture.md
+```
+
+우리 최종 산출 기준에도 `README / LICENSE / CONTRIBUTING / SECURITY / CODE_OF_CONDUCT / PR 템플릿`이 포함되어 있습니다. 
+
+---
+
+# 머지 전 확인해야 할 부분
+
+## 1. README가 “현재 상태”와 “목표 상태”를 헷갈리게 쓰면 안 됩니다
+
+가장 중요한 체크입니다.
+
+이번 PR 시점에서는 아직 다음이 없습니다.
+
+```text
+현대 Kotlin + Compose app
+Article 모델
+Reducer
+ViewModel + StateFlow
+테스트
+CI
+v0.1.0 release
+```
+
+따라서 README에 아래처럼 쓰면 위험합니다.
+
+```md
+This project provides a modern Kotlin + Compose app with StateFlow and tests.
+```
+
+아직 구현 전이라면 이렇게 바꾸는 게 좋습니다.
+
+```md
+This project is being rebuilt as a modern Kotlin + Compose migration lab.
+
+Current status:
+- OSS metadata and documentation baseline are being prepared.
+- The modern Kotlin + Compose app will be added in the next implementation PR.
+```
+
+추천 문구:
+
+```md
+## Current status
+
+This repository is in the initial OSS setup phase.
+
+Completed:
+- Project direction clarified
+- OSS metadata added
+- Legacy README preserved as documentation
+
+Next:
+- Add modern Kotlin + Compose app baseline
+- Add Article state model
+- Add ViewModel + StateFlow sample
+- Add tests and CI
+```
+
+이렇게 쓰면 신규 방문자가 “왜 아직 앱이 안 돌아가지?”라고 혼란스러워하지 않습니다.
+
+## 2. `CHANGELOG.md`는 `Unreleased`부터 시작하는 게 안전합니다
+
+이번 PR에서 `CHANGELOG.md`를 추가했다면, 아직 `v0.1.0-oss-alpha.1`이 나온 상태가 아니므로 아래처럼 쓰는 게 좋습니다.
+
+```md
+# Changelog
+
+## Unreleased
+
+### Added
+- Rewrote README for Android ViewModel Migration Lab direction
+- Added OSS metadata files
+- Added GitHub pull request and issue templates
+- Preserved original README content as legacy architecture documentation
+```
+
+아래처럼 쓰면 조금 이릅니다.
+
+```md
+## v0.1.0-oss-alpha.1
+```
+
+`v0.1.0-oss-alpha.1`은 실제로 현대 앱, 테스트, CI, 문서가 갖춰진 뒤 태그를 만들기로 했습니다. 수정본 계획에서도 최종 산출 기준에 `v0.1.0-oss-alpha.1` 태그 생성을 마지막 기준으로 두고 있습니다. 
+
+## 3. PR 본문에 “빌드/테스트 미실행 사유”를 명확히 쓰는 게 좋습니다
+
+PR 본문에는 `How I tested this` 영역이 있고, `I ran ...` 체크박스가 비어 있는 것으로 보입니다. 
+
+이번 PR은 문서/메타데이터 전용이라 `./gradlew test`나 `./gradlew assembleDebug`를 아직 강제하지 않아도 됩니다. 다만 비어 있으면 보는 사람이 “검증 안 한 PR인가?”라고 느낄 수 있습니다.
+
+추천 수정:
+
+```md
+## How I tested this
+
+- [x] Reviewed Markdown rendering locally/GitHub preview
+- [x] Confirmed this PR does not change app source code
+- [ ] I ran `./gradlew test`
+  - Not applicable yet: this PR only adds OSS metadata/docs.
+- [ ] I ran `./gradlew assembleDebug`
+  - Not applicable yet: modern Android app baseline will be added in a follow-up PR.
+```
+
+또는 PR 템플릿 자체에 이것을 추가하면 좋습니다.
+
+```md
+- [ ] Not applicable: docs-only change
+```
+
+## 4. `docs/01-legacy-architecture.md`는 “원본 README 보존”이라는 성격을 명확히 해야 합니다
+
+PR 설명에 기존 baseline을 `docs/01-legacy-architecture.md`로 보존했다고 되어 있습니다. 
+
+좋습니다. 다만 이 문서는 “최신 가이드”가 아니라 “원본 기록”입니다.
+
+파일 맨 위에 아래 안내문을 넣는 것을 추천합니다.
+
+```md
+> This document preserves the original README and legacy architecture notes.
+> It describes the 2017-era sample and may reference outdated Android tooling.
+> The modern migration guide starts from `docs/02-modern-architecture.md`.
+```
+
+한국어로는:
+
+```md
+> 이 문서는 원본 README와 2017년식 구조를 보존하기 위한 문서입니다.
+> 오래된 Android 도구와 의존성을 언급할 수 있습니다.
+> 현대화 문서는 `docs/02-modern-architecture.md`부터 작성됩니다.
+```
+
+이걸 넣어두면 나중에 누가 봐도 “이 문서가 왜 오래된 내용을 담고 있는지” 이해할 수 있습니다.
+
+# PR 코멘트로 남기면 좋은 리뷰 문구
+
+아래 내용을 그대로 GitHub 리뷰 코멘트로 남기면 좋습니다.
+
+```md
+Overall direction looks good. This is an appropriate first PR because it focuses on repository identity, OSS metadata, contribution docs, and preserving the legacy baseline before touching the Android build.
+
+Before merging, I recommend clarifying three things:
+
+1. README should clearly separate current status from roadmap. Since the modern Kotlin/Compose app, StateFlow ViewModel, tests, and CI are not implemented yet, please avoid wording that sounds like they already exist.
+2. CHANGELOG should start with `Unreleased` instead of treating `v0.1.0-oss-alpha.1` as already released.
+3. In the PR description, please mark Gradle build/test as “not applicable yet” because this PR is docs/metadata-only.
+
+After those small adjustments, this PR is safe to merge as the OSS setup baseline.
+```
+
+# 제안하는 PR 본문 수정안
+
+현재 PR 본문은 방향은 좋은데, 첫 PR이라면 아래처럼 조금 더 명확하게 바꾸는 것을 추천합니다.
+
+```md
+## Summary
+
+This PR sets up the repository as a beginner-friendly Android ViewModel Migration Lab.
+
+It does not change Android app source code yet.
+
+## Changes
+
+- Rewrites README to describe the OSS migration lab direction
+- Adds OSS metadata files:
+  - LICENSE
+  - CONTRIBUTING.md
+  - SECURITY.md
+  - CODE_OF_CONDUCT.md
+  - CHANGELOG.md
+- Adds GitHub templates:
+  - Pull request template
+  - Bug report issue template
+  - Migration task issue template
+- Preserves the original README content in `docs/01-legacy-architecture.md`
+- Adds OSS remake task/reference documentation
+
+## Current status
+
+Completed in this PR:
+- OSS metadata setup
+- Repository direction clarified
+- Legacy README preserved
+
+Not included yet:
+- Modern Kotlin + Compose app
+- Article domain model
+- Reducer
+- ViewModel + StateFlow
+- Tests
+- CI
+
+## How I tested this
+
+- [x] Reviewed Markdown rendering
+- [x] Confirmed this PR is docs/metadata-only
+- [ ] `./gradlew test`
+  - Not applicable yet. Modern app baseline will be added in a follow-up PR.
+- [ ] `./gradlew assembleDebug`
+  - Not applicable yet. Modern app baseline will be added in a follow-up PR.
+
+## Next PRs
+
+- Add modern Kotlin + Compose app baseline
+- Move legacy app into archive structure if needed
+- Add Article state model and reducer
+- Add reducer tests
+```
+
+# 다음 PR 추천
+
+이 PR이 머지되면 다음 PR은 바로 코드로 가기 전에 **현대 앱 뼈대 정비 PR**이 좋습니다.
+
+## PR #4 추천 제목
+
+```text
+Add modern Kotlin Compose app baseline
+```
+
+## PR #4 범위
+
+```text
+기존 app/ → legacy-app/
+새 Kotlin + Compose app/ 추가
+settings.gradle.kts 정리
+build.gradle.kts 정리
+./gradlew assembleDebug 통과
+```
+
+아직 Article/Reducer/ViewModel까지 넣지 않는 게 좋습니다.
+PR #4는 “빌드 가능한 현대 Android 뼈대”만 만드는 PR로 두세요.
+
+그 다음에:
+
+```text
+PR #5: Add Article state model and reducer
+PR #6: Add reducer tests
+PR #7: Add StateFlow ViewModel
+PR #8: Add Compose list/detail screens
+PR #9: Add Android CI workflow
+```
+
+이 순서가 안전합니다.
+
+---
+
+# 최종 판단
+
+**PR #3은 첫 PR로 좋습니다.**
+저라면 아래 조건으로 머지합니다.
+
+```text
+조건부 머지 OK
+```
+
+머지 전 필수 확인:
+
+* README가 현재 구현 상태를 과장하지 않는다.
+* CHANGELOG는 `Unreleased`부터 시작한다.
+* PR 본문에 docs-only라서 build/test 미실행이 정상임을 쓴다.
+* Reserve.M/예약/매출/ダブルブッキング 문구가 없다.
+* `docs/01-legacy-architecture.md`가 “원본 보존 문서”임을 명시한다.
+
+이 정도만 정리하면, 계획서 기준으로 **0~1단계 착수 PR로 매우 적절합니다.**

--- a/docs/oss-remake-plan-reference.md
+++ b/docs/oss-remake-plan-reference.md
@@ -1,0 +1,2380 @@
+# 초보자용 전체 진행 순서
+
+목표는 이겁니다.
+
+> 기존 `Android-AAC-ViewModel-Practice`를
+> **“옛날 Android 코드를 최신 Android 방식으로 바꾸는 학습용 오픈소스 프로젝트”**로 바꾸기
+
+현재 저장소는 이미 좋은 주제를 가지고 있습니다. README에는 **여러 화면에서 같은 Article 데이터를 공유하고, Detail 화면에서 수정하면 List 화면도 갱신되는 구조**가 설명되어 있습니다. 
+하지만 코드는 er()`와 Android Gradle Plugin `2.3.1`을 쓰고 있고, :contentReference[oaicite:2]{index=2} `compileSdkVersion 25`, Support Library 25, Lifecycle `1.0.0-alpha1`을 사용합니다. 
+
+그래서 우리는 이 저장소를 이렇게 바꿉니다.
+
+````text
+옛날 Android AAC 연습 프로젝트
+↓
+레거시 Android ViewModel . 아주 쉽게 비유하면 이렇습니다.
+
+| 단어 | 아주 쉬운 뜻 |
+|---|---|
+| GitHub | 내 프로젝트를 올려두는 인터넷 책장 |
+| Repository / repo | 프로젝트 폴더 |
+| Branch | 원본을 망치지 않기 위한 복사본 길 |
+| Commit | 저장 지점 |
+| Pull Request / PR | “이렇게 고쳤어요, 확인해주세요”라고 올리는 변경 묶음 |
+| README | GitHub 프로젝트 첫 화면 설명서 |
+| CI | GitHub가 자동으로 코드를 검사해주는 로봇 |
+| License | 다른 사람이 이 코드를 써도 되는지 알려주는 규칙 |
+| Android Studio | Android 앱을 만드는 프로그램 |
+| Gradle | Android 앱을 조립해주는 도구 |
+| ViewModel | 화면에 보여줄 데이터를 보관하는 상자 |
+| StateFlow | 데이터가 바뀌면 화면에 알려주는 현대식 흐름 |
+| Compose | Android 화면을 만드는 최신 방식 중 하나 |
+
+---
+
+# 1. 전체 큰 그림
+
+이 프로젝트는 한 번에 완성하지 않습니다.
+
+작은 단계로 나눠서 진행합니다.
+
+```text
+1단계: 원본 저장하기
+2단계: README 바꾸기
+3단계: 오픈소스 기본 파일 만들기
+4단계: 최신 Android 프로젝트 뼈대 만들기
+5단계: Article 데이터 구조 만들기
+6단계: ViewModel 만들기
+7단계: 테스트 만들기
+8단계: 화면 만들기
+9단계: 문서 만들기
+10단계: Codex for OSS 제출 준비하기
+````
+
+중요한 원칙은 이것입니다.
+
+> **한 번에 큰 수정 금지.**
+> 작은 수정 → 저장 → 확인 → GitHub에 올리기 → 다음 수정
+
+---
+
+# 2. 준비물 설치하기
+
+## 2-1. 필요한 프로그램
+
+먼저 아래 프로그램이 필요합니다.
+
+| 프로그램           | 용도                      |
+| -------------- | ----------------------- |
+| GitHub 계정      | 프로젝트 관리                 |
+| GitHub Desktop | 초보자가 Git을 쉽게 쓰기 위한 프로그램 |
+| Android Studio | Android 앱 만들기           |
+| Git            | 코드 저장/업로드 도구            |
+| Java 17        | Android 빌드에 필요한 도구      |
+
+초보자라면 **GitHub Desktop**을 꼭 쓰는 것을 추천합니다. 터미널 명령어를 많이 몰라도 됩니다.
+
+---
+
+## 2-2. 폴더 만들기
+
+컴퓨터에 작업 폴더를 하나 만듭니다.
+
+예:
+
+```text
+Documents/
+└─ oss-projects/
+```
+
+이 안에 프로젝트를 받을 겁니다.
+
+---
+
+# 3. GitHub에서 프로젝트 가져오기
+
+## 3-1. GitHub Desktop으로 가져오기
+
+1. GitHub Desktop 실행
+2. itory`
+3. `URL` 선택
+4. 아래 주소 입력
+
+```text
+https://github.com/leesunghyun/Android-AAC-ViewModel-Practice
+```
+
+6. 저장 위치를 선택
+
+```text
+Documents/oss-projects/
+```
+
+7. `Clone` 버튼 클릭
+
+성공하면([Android Developers][1])니다.
+
+```text
+Documents/oss-projects/Android-AAC-ViewModel-Practice
+```
+
+---
+
+## ([Android Developers][1])io로 열기
+
+1. Android Studio 실행
+2. `Open` 클릭
+3. 방금 받은 폴더 선택
+
+```text
+Android-AAC-ViewModel-Practice
+```
+
+4. 프로젝트가 열릴 때까지 기다립니다.
+
+처음에는 에러가 날 가능성이 높습니다. 괜찮습니다. 이 프로젝트는 오래된 프로젝트라서 당연합니다.
+
+---
+
+# 4. 1단계: 원본 저장하기
+
+가장 먼저 해야 할 일은 **옛날 코드를 안전하게 보관하는 것**입니다.
+
+왜냐하면 앞으로 많이 고칠 예정이라 원본을 잃어버리면 안 됩니다.
+
+---
+
+## 4-1. GitHub Desktop에서 branch 만들기
+
+1. GitHub Desktop 열기
+2. 현재 repository가 `Android-AAC-ViewModel-Practic([OpenAI][2])nch 이름 클릭
+3. `New Branch` 클릭
+4. branch 이름 입력
+
+```text
+legacy/2017-original
+```
+
+6. `Create Branch` 클릭
+7. `Publish branch` 클릭
+
+이렇게 하면([OpenAI][2])ranch가 생깁니다.
+
+---
+
+## 4-2. 원본 tag 만들기
+
+이건 터미널에서 해야 합니다.
+
+Android Studio 아래쪽에 `Terminal` 탭을 엽니다.
+
+아래 명령어를 한 줄씩 입력합니다.
+
+```bash
+git checkout master
+git tag v0.0.0-legacy-2017
+git push origin v0.0.0-legacy-2017
+```
+
+성공하면 원본 저장 지점이 생깁니다.
+
+뜻은 이겁니다.
+
+```text
+v0.0.0-legacy-2017
+= 2017년 원본 상태를 저장한 이름표
+```
+
+---
+
+## 4-3. 성공 확인
+
+GitHub 웹사이트에서 repository에 들어갑니다.
+
+확인할 것:
+
+* branch 목록에 `legacy/2017-original`이 있는가?
+* tag 목록에 `v0.0.0-legacy-2017`이 있는가?
+
+있으면 성공입니다.
+
+---
+
+# 5. 2단계: main branch 만들기
+
+옛날 프로젝트는 `master` branch를 쓰고 있을 가능성이 높습니다.
+
+요즘은 보통 `main`을 씁니다.
+
+---
+
+## 5-1. GitHub Desktop에서 main branch 만들기
+
+1. GitHub Desktop 열기
+2. 현재 branch를 `master`로 변경
+3. branch 메뉴 ``text
+   main
+
+````
+
+6. `Create Branch`
+7. `Publish branch`
+
+---
+
+## 5-2. GitHub 기본 branchitory 들어가기
+2. `Settings`
+3. 왼쪽 메뉴 `Branches`
+4. `Default branch`
+5. `main`으로 변경
+
+---
+
+## 5-3. 성공 확인
+
+GitHub repository 첫 화면에서 branch가 `main`으로 보이면 성공입니다.
+
+---
+
+# 6. 3단계: 프로젝트 이름과 설명 바꾸기
+
+지금 이름은 e`입니다.
+
+그냥 써도 되지만, 제출용으로는 조금 약합니다.  
+가능하면 이름을 바꾸는가장 추천하는 이름:
+
+```text
+android-viewmodel-migration-lab
+````
+
+뜻:
+
+```text
+Android ViewModel을 옛날 방식에서 최신 방식으로 바꾸는 실험실
+```
+
+---
+
+## 6-2. GitHub에서 이름 바꾸기
+
+1. GitHub repository 들어가기
+2. name`
+3. 아래 이름으로 변경
+
+```text
+android-viewmodel-migration-lab
+```
+
+5. `Rename` ub repository 첫 화면에서 오른쪽 위나 About 영역에 설명을 넣습니다.
+
+```text
+A practical migration lab for modernizing legacy Android ViewModel and LiveData apps.
+```
+
+한국어로 뜻은:
+
+```text
+오래된 Android ViewModel / LiveData 앱을 최신 방식으로 바꾸는 학습 프로젝트
+```
+
+---
+
+# 7. 4단계: README 바꾸기
+
+README는 프로젝트의 얼굴입니다.
+
+현재 README는 Demo, Branch, purpose 중심으로 되어 있고, `basic-livedata-viewmodel`, `dagger`, `dagger-databinding` branch 설명이 있습니다. 
+이제 README를 제출용으로 바꿔야 합니다.
+
+---
+
+## 7-1. 기존 README 백업하기
+
+프로젝트 폴더에서 새 폴더를 만듭니다.
+
+```text
+docs/
+```
+
+그리고 기존 `README.md` 내용을 복사해서 새 파일에 붙여넣습니다.
+
+파일 이름:
+
+```text
+docs/01-legacy-architecture.md
+```
+
+제목은 이렇게 바꿉니다.
+
+```md
+# 2017 Legacy Architecture
+```
+
+---
+
+## 7-2. 새 README 만들기
+
+루트에 있는 `README.md`를 열고 전부 지운 뒤 아래 내용을 넣습니다.
+
+```md
+# Android ViewModel Migration Lab
+
+A practical migration lab for maintainers of legacy Android apps.
+
+This repository starts from a real 2017-era Android Architecture Components sample built with Java, Support Library, LiveData alpha, DataBinding, Dagger 2, and manual Fragment transactions.
+
+It modernizes the same shared-state problem step by step using AndroidX, Kotlin, StateFlow, Hilt, Navigation, and Jetpack Compose.
+
+## What problem does this project solve?
+
+Many legacy Android apps share the ens.
+
+In the original sample, an Article is shown in a list screen and edited in a detail screen. When the detail screen saves the Article, the list screen should also show the updated data.
+
+This project shows how to solve that problem in both legacy and modern Android styles.
+
+## Migration Map
+
+| Legacy sample | Modern version |
+|---|---|
+| Java | Kotlin |
+| Support Library | AndroidX |
+| LiveData alpha | StateFlow |
+| DataBinding | Compose |
+| Dagger 2:contentReference[oaicite:20]{index=20}l Fragment transactions | Navigation |
+| Mutable nested state | Immutable UI state |
+| No CI | GitHub Actions |
+
+## Project Goals
+
+- Preserve the original 2017 Android Architecture Components idea
+- Explain the legacy architecture
+- Rebuild the sample with modern Android tools
+- Add tests for shared state updates
+- Provide step-by-step migration guides
+
+## Roadmap
+
+- [ ] Preserve the 2017 legacy baseline
+- [ ] Add modern Android project baseline
+- [ ] Extract Article domain model
+- [ ] Replace nested LiveData with StateFlow
+- [ ] Add ViewModel tests
+- [ ] Add Navigation example
+- [ ] Add Hilt example
+- [ ] Add Compose example
+- [ ] Prepare v1.0.0 release
+
+## Documentation
+
+- [2017 Legacy Architecture](docs/01-legacy-architecture.md)
+
+## License
+
+This project is licensed under the Apache License 2.0.
+```
+
+---
+
+## 7-3. 저장하고 commit 하기
+
+GitHub Desktop에서:
+
+1. 변경 파일 확인
+2. 아래 summary에 입력
+
+```text
+Rewrite README as Android ViewModel migration lab
+```
+
+3. `Commit to main`
+4. `Push origin`
+
+---
+
+## 7-4. 성공 확인
+
+GitHub repository 첫 화면에 새 README가 보이면 성공입니다.
+
+---
+
+# 8. 5단계: 오픈소스 기본 파일 만들기
+
+오픈소스처럼 보이려면 기본 문서가 필요합니다.
+
+만들 파일은 5개입니다.
+
+```text
+LICENSE
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+.github/pull_request_template.md
+```
+
+---
+
+## 8-1. LICENSE 만들기
+
+루트 폴더에 `LICENSE` 파일을 만듭니다.
+
+추천은 Apache-2.0입니다.
+
+초보자는 GitHub에서 자동 생성하는 게 쉽습니다.
+
+1. GitHub repository 접속
+2. `Add file`
+3. `Create new file`
+4. 파일 이름에 입력
+
+```text
+LICENSE
+```
+
+5. 오른쪽에 `Choose a license template`
+6. `Apache License 2.0` 선택
+7. 저장
+
+---
+
+## 8-2. CONTRIBUTING.md 만들기
+
+루트에 `CONTRIBUTING.md` 파일을 만들고 아래 내용을 넣습니다.
+
+```md
+# Contributing
+
+Thank you for your interest in contributing.
+
+This project is a learning-focused migration lab for legacy Android architecture.
+
+## How to contribute
+
+1. Pick an issue from the roadmap.
+2. Create a small pull request.
+3. Explain what changed.
+4. Add or update tests when possible.
+5. Update documentation when the migration behavior changes.
+
+## Pull request rules
+
+- Keep each pull request small.
+- Do not mix unrelated changes.
+- Prefer readable code over clever code.
+- Add documentation for migration steps.
+```
+
+---
+
+## 8-3. SECURITY.md 만들기
+
+루트에 `SECURITY.md` 파일을 만들고 아래 내용을 넣습니다.
+
+```md
+# Security Policy
+
+This project is an educational Android migration sample.
+
+If you find a security issue in the sample code or documentation, please open an issue with a clear explanation.
+
+Do not include secrets, API keys, or private credentials in issues or pull requests.
+```
+
+---
+
+## 8-4. PR template 만들기
+
+폴더를 만듭니다.
+
+```text
+.github/
+```
+
+그 안에 파일을 만듭니다.
+
+```text
+.github/pull_request_template.md
+```
+
+내용:
+
+```md
+## Summary
+
+Explain what changed.
+
+## Migration step
+
+Which migration step  ] Documentation
+- [ ] Gradle / build
+- [ ] AndroidX
+- [ ] Kotlin
+- [ ] StateFlow
+- [ ] Navigatio [ ] Tests
+
+## Checklist
+
+- [ ] I kept this PR small
+- [ ] I updated documentation if needed
+- [ ] I added or updated tests if needed:contentReference[oaicite:23]{index=23}t builds locally
+```
+
+---
+
+## 8-5. commit 하기
+
+GitHub Desktop에서 summary 입력:
+
+```text
+Add open source project files
+```
+
+그리고:
+
+```text
+Commit to main
+Push origin
+```
+
+---
+
+# 9. 6단계: 작업 목록을 GitHub Issues로 만들기
+
+이제 해야 할 일을 GitHub Issues에 적어둡니다.
+
+이건 숙제 목록 같은 겁니다.
+
+---
+
+## 9-1. Issue 만들기
+
+GitHub repository에서:
+
+1. `Issues`
+2. `New issue`
+3. 제목과 내용을 넣고 저장
+
+---
+
+## 9-2. 만들 Issue 목록
+
+아래 제목으로 하나씩 만듭니다.
+
+```text
+Preserve 2017 legacy baseline
+Rewrite project documentation
+Add modern Android Gradle baseline
+Add GitHub Actions CI
+Extract Article domain model
+Add Article state reducer tests
+Replace nested LiveData with StateFlow
+Add modern ViewModel sample
+Add Navigation migration guide
+Add Hilt migration guide
+Add Compose UI sample
+Prepare Codex for OSS application notes
+```
+
+---
+
+## 9-3. Issue 예시
+
+제목:
+
+```text
+Extract Article domain model
+```
+
+내용:
+
+```md
+## Goal
+
+Crat can be used without Android UI code.
+
+## Tasks
+
+- [ ] Create Article data class
+- [ ] Create ArticleId value class
+- [ ] Create sample Article list
+- [ ] Add unit tests
+
+## Done when
+
+- Article state can be tested without running the Android app.
+```
+
+---
+
+# 10. 7단계: 최신 Android 프로젝트를 새로 만들기
+
+여기부터 코딩이 조금 들어갑니다.
+
+초보자에게 가장 쉬운 방법은 **기존 오래된 Android 설정을 억지로 고치지 않고, Android Studio에서 새 프로젝트를 만든 뒤 필요한 파일을 가져오는 것**입니다.
+
+---
+
+## 10-1. 새 Android 프로젝트 만들기
+
+Android Studio에서:
+
+1. `File`
+2. `New`
+3. `New Project`
+4. `Empty Activity` 또는 `Empty Compose Activity` 선택
+5. 이름 입력
+
+```text
+AndroidViewModelMigrationLab
+```
+
+6. Language는 `Kotlin`
+7. Minimum SDK는 너무 고민하지 말고 기본값 사용
+8. Finish
+
+---
+
+## 10-2. 새 프로젝트가 잘 실행되는지 확인
+
+Android Studio 위쪽에서 초록색 실행 버튼을 누릅니다.
+
+에뮬레이터나 연결된 Android 기기에서 앱이 뜨면 성공입니다.
+
+처음 화면이 단순히 `Hello Android` 같은 화면이어도 괜찮습니다.
+
+---
+
+## 10-3. 새 프로젝트 파일을 기존 repo에 옮기기
+
+이제 새 프로젝트의 주요 파일을 기존 repo로 옮깁니다.
+
+옮길 것:
+
+```text
+settings.gradle.kts
+build.gradle.kts
+gradle/
+gradlew
+gradlew.bat
+app/
+```
+
+주의:
+
+* 기존 repo 안의 오래된 `app/`은 바로 지우지 말고 백업합니다.
+* 먼저 이름을 바꿉니다.
+
+```text
+app/
+↓
+legacy-app/
+```
+
+그리고 새 프로젝트의 `app/`을 복사해 넣습니다.
+
+결과:
+
+```text
+android-viewmodel-migration-lab/
+├─ legacy-app/
+├─ app/
+├─ docs/
+├─ README.md
+├─ LICENSE
+├─ settings.gradle.kts
+├─ build.gradle.kts
+├─ gradlew
+└─ gradlew.bat
+```
+
+---
+
+## 10-4. Android Studio에서 다시 열기
+
+1. Android Studio 종료
+2. 다시 Android Studio 실행
+3. repo 폴더 열기
+
+```text
+android-viewmodel-migration-lab
+```
+
+4. Sync가 끝날 때까지 기다리기
+
+---
+
+## 10-5. 성공 확인
+
+Android Studio 아래 `Terminal`에서:
+
+```bash
+./gr:contentReference[oaicite:25]{index=25}ug
+```
+
+Windows라면:
+
+````bash
+gradlew.bat assembleDebug
+``:contentReference[oaicite:26]{index=26}이 나옵니다.
+
+```text
+BUILD SUCCESSFUL
+````
+
+---
+
+## 10-6. commit 하기
+
+GitHub Desktop summary:
+
+```text
+Add modern Android project baseline
+```
+
+Push까지 합니다.
+
+---
+
+# 11. 8단계: GitHub Actions CI 만들기
+
+CI는 GitHub가 자동으로 검사해주는 로봇입니다.
+
+우리가 push하거나 PR을 만들면 자동으로 빌드합니다.
+
+---
+
+## 11-1. workflow 파일 만들기
+
+폴더:
+
+```text
+.github/workflows/
+```
+
+파일:
+
+```text
+.github/workflows/android.yml
+```
+
+내용:
+
+```yaml
+name: Android CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Build debug app
+        run: ./gradlew assembleDebug
+```
+
+---
+
+## 11-2. commit 하기
+
+GitHub Desktop summary:
+
+```text
+Add Android CI workflow
+```
+
+Push합니다.
+
+---
+
+## 11-3. 성공 확인
+
+GitHub에서:
+
+1. repository 들어가기
+2. `Actions`
+3. `Android CI` 클릭
+4. 초록색 체크가 뜨면 성공
+
+빨간색이면 실패입니다. 실패해도 괜찮습니다. 에러 메시지를 보고 고치면 됩니다.
+
+---
+
+# 12. 9단계: Article 모델 만들기
+
+이 프로젝트의 주인공은 `Article`입니다.
+
+옛날 코드에서도 `ArticleListFragment`와 `ArticleDetailFragment`가 Article을 공유합니다. Detail 화면은 ViewModel에서 Article list를 가져와 특정 Article을 사용합니다. 
+
+이제 이걸 더 깨끗하게 만듭니다.
+
+---
+
+## 12-1. 폴더 만text
+
+app/src/main/java/...
+
+````
+
+아래에 패키지를 만듭니다.
+
+추천 패키지 이름:
+
+```text
+com.example.viewmodelmigration
+````
+
+그 안에 폴더를 만듭니다.
+
+```text
+core/
+```
+
+최종:
+
+```text
+app/src/main/java/com/example/viewmodelmigration/core/
+```
+
+---
+
+## 12-2. Article.kt 만들기
+
+파일:
+
+```text
+Article.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+data class Article(
+    val id: String,
+    val title: String,
+    val body: String
+)
+```
+
+뜻:
+
+```text
+Article은 id, title, body를 가진 글 하나입니다.
+```
+
+---
+
+## 12-3. SampleArticles.kt 만들기
+
+파일:
+
+```text
+SampleArticles.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+object SampleArticles {
+    fun create(): List<Article> {
+        return listOf(
+            Article(
+                id = "1",
+                title = "Legacy ViewModel",
+                body = "This article explains dea."
+            ),
+            Article(
+                id = "2",
+                
+                body = "This article explains how to migrate LiveData to StateFlow."
+            ),
+            Article(
+                id = "3",
+                title = "Compose UI",
+                body = "This article explains how to render state with Compose."
+            )
+        )
+    }
+}
+```
+
+---
+
+## 12-4. commit 하기
+
+GitHub Desktop summary:
+
+```text
+Add Article domain model
+```
+
+Push합니다.
+
+---
+
+# 13. 10단계: 화면 상태 만들기
+
+화면에 필요한 데이터를 한 상자에 넣겠습니다.
+
+---
+
+## 13-1. ArticleListUiState.kt 만들기
+
+파일:
+
+```text
+ArticleListUiState.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+data class ArticleListUiState(
+    val articles: List<Article> = emptyList(),
+:contentReference[oaicite:31]{index=31}rticleId: String? = null
+)
+```
+
+뜻:
+
+```text
+ArticleListUiState
+= 화면이 지금 보여줘야 하는 상태
+:contentReference[oaicite:32]{index=32}articles = 글 목록
+selectedArticleId = 지금 선택한 글 id
+```
+
+---
+
+## 13-2. ArticleListAction.kt 만들기
+
+파일:
+
+```text
+ArticleListAction.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+sealed interface ArticleListAction {
+    data class SelectArticle(val articleId: String) : ArticleListAction
+    data class UpdateArticle(val article: Article) : ArticleListAction
+    data class DeleteArticle(val articleId: String) : ArticleListAction
+}
+```
+
+뜻:
+
+```text
+Action
+= 사용자가 한 행동
+```
+
+예:
+
+```text
+글 선택하기
+글 수정하기
+글 삭제하기
+```
+
+---
+
+# 14. 11단계: 상태를 바꾸는 함수 만들기
+
+이제 사용자가 행동했을 때 상태가 어떻게 바뀌는지 만듭니다.
+
+---
+
+## 14-1. ArticleListReducer.kt 만들기
+
+파일:
+
+```text
+ArticleListReducer.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+object ArticleListReducer {
+
+    fun reduce(
+        state: ArticleListUiState,
+        action: ArticleListAction
+    ): ArticleListUiState {
+        return when (action) {
+            is ArticleListAction.SelectArticle -> {
+                state.copy(
+                    selectedArticleId = action.articleId
+                )
+            }
+
+            is ArticleListAction.UpdateArticle -> {
+                state.copy(
+                    articles = state.articles.map { article ->
+                        if (article.id == action.article.id) {
+                            action.article
+                        } else {
+                            article
+                        }
+                    }
+                )
+            }
+
+            is ArticleListAction.DeleteArticle -> {
+                state.copy(
+                    articles = state.articles.filterNot { article ->
+                        article.id == action.articleId
+                    },
+                    selectedArticleId = if (state.selectedArticleId == action.articleId) {
+                        null
+                    } else {
+                        state.selectedArticleId
+                    }
+                )
+            }
+        }
+    }
+}
+```
+
+쉽게 말하면:
+
+```text
+SelectArticle → 선택한 글 id를 저장
+UpdateArticle → 같은 id를 가진 글을 새 글로 교체
+DeleteArticle → 해당 id의 글을 목록에서 제거
+```
+
+---
+
+## 14-2. 왜 이게 중요한가
+
+이 함수는 Android 화면 없이도 테스트할 수 있습니다.
+
+즉, 앱을 실행하지 않아도:
+
+```text
+글 수정하면 목록도 바뀌는가?
+```
+
+를 확인할 수 있습니다.
+
+이게 오픈소스 프로젝트에서 아주 좋은 점입니다.
+
+---
+
+# 15. 12단계: 테스트 만들기
+
+테스트는 “내 코드가 맞는지 확인하는 자동 채점기”입니다.
+
+---
+
+## 15-1. 테스트 폴더 확인
+
+아래 폴더가 있어야 합니다.
+
+```text
+app/src/test/java/
+```
+
+없으면 만듭니다.
+
+그 안에 패키지를 만듭니다.
+
+```text
+com/example/viewmodelmigration/core/
+```
+
+최종:
+
+```text
+app/src/test/java/com/example/viewmodelmigration/core/
+```
+
+---
+
+## 15-2. ArticleListReducerTest.kt 만들기
+
+파일:
+
+```text
+ArticleListReducerTest.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ArticleListReducerTest {
+
+    @Test
+    fun updateArticle_updatesArticleInList() {
+        val oldArticle = Article(
+            id = "1",
+            title = "Old title",
+            body = "Old body"
+        )
+
+        val newArticle = Article(
+            id = "1",
+            title = "New title",
+            body = "New body"
+        )
+
+        val oldState = ArticleListUiState(
+            articles = listOf(oldArticle)
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.UpdateArticle(newArticle)
+        )
+
+        assertEquals("New title", newState.articles.first().title)
+        assertEquals("New body", newState.articles.first().body)
+    }
+
+    @Test
+    fun selectArticle_updatesSelectedArticleId() {
+        val oldState = ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+
+        val newState = ArticleListReducer.reduce(,
+            action = ArticleListAction.SelectArticle("2")
+        )
+
+        assertEquals("2", newState.selectedArticleId)
+    }
+
+    @Test
+    fun deleteArticle_removesArticleFromList() {
+        val oldState = ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.DeleteArticle("1")
+        )
+
+        assertEquals(2, newState.articles.size)
+    }
+
+    @Test
+    fun deleteSelectedArticle_clearsSelectedArticleId() {
+        val oldState = ArticleListUiState(
+            articles = SampleArticles.create(),
+            selectedArticleId = "1"
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.DeleteArticle("1")
+        )
+
+        assertNull(newState.selectedArticleId)
+    }
+}
+```
+
+---
+
+## 15-3. 테스트 실행하기
+
+Android Studio 아래 Terminal에서:
+
+```bash
+./gradlew test
+```
+
+Windows:
+
+```bash
+gradlew.bat test
+```
+
+성공하면:
+
+```text
+BUILD SUCCESSFUL
+```
+
+---
+
+## 15-4. commit 하기
+
+GitHub Desktop summary:
+
+```text
+Add Article state reducer tests
+```
+
+Push합니다.
+
+---
+
+# 16. 13단계: ViewModel 만들기
+
+이제 화면이 사용할 ViewModel을 만듭니다.
+
+옛날 코드는 `ArticleListViewModel`이 `MutableLiveData<List<MutableLiveData<Article>>>`를 가지고 있었습니다. 
+새 코드는 더 단순하게 `ArticleListUiState` 하나를 관리합니다.
+
+---
+
+## 16-1. ViewModel 파일 만들기
+
+패키지:
+
+```text
+app/src/main/java/com/example/viewmodelmigration/viewmodel/
+```
+
+파일:
+
+```text
+ArticleListViewModel.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.example.viewmodelmigration.core.Article
+import com.example.viewmodelmigration.core.ArticleListAction
+import com.example.viewmodelmigration.core.ArticleListReducer
+import com.example.viewmodelmigration.core.ArticleListUiState
+import com.example.viewmodelmigration.core.SampleArticles
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class ArticleListViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+    )
+
+    val uiState: StateFlow<ArticleListUiState> = _uiState.asStateFlow()
+
+    fun selectArticle(articleId: String) {
+        dispatch(ArticleListAction.SelectArticle(articleId))
+    }
+
+    fun updateArticle(article: Article) {
+        dispatch(ArticleListAction.UpdateArticle(article))
+    }
+
+    fun deleteArticle(articleId: String) {
+        dispatch(ArticleListAction.DeleteArticle(articleId))
+    }
+
+    private fun dispatch(action: ArticleListAction) {
+        _uiState.update { oldState ->
+            ArticleListReducer.reduce(oldState, action)
+        }
+    }
+}
+```
+
+---
+
+## 16-2. 에러가 날 수 있는 부분
+
+`MutableStateFlow`에서 에러가 나면 Gradle dependencies에 coroutine이 빠졌을 수 있습니다.
+
+그때는 `app/build.gradle.kts`에 아래가 있는지 확인합니다.
+
+```kotlin
+implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+```
+
+버전은 프로젝트 상황에 따라 달라도 됩니다.
+
+---
+
+## 16-3. commit 하기
+
+GitHub Desktop summary:
+
+```text
+Add StateFlow ArticleListViewModel
+```
+
+Push합니다.
+
+---
+
+# 17. 14단계: ViewModel 테스트 만들기
+
+이제 ViewModel이 제대로 동작하는지 확인합니다.
+
+---
+
+## 17-1. ArticleListViewModelTest.kt 만들기
+
+폴더:
+
+```text
+app/src/test/java/com/example/viewmodelmigration/viewmodel/
+```
+
+파일:
+
+```text
+ArticleListViewModelTest.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.viewmodel
+
+import com.example.viewmodelmigration.core.Article
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArticleListViewModelTest {
+
+    @Test
+    fun updateArticle_updatesUiState() {
+        val viewModel = ArticleListViewModel()
+
+        val newArticle = Article(
+            id = "1",
+            title = "Updated title",
+            body = "Updated body"
+        )
+
+        viewModel.updateArticle(newArticle)
+
+        val state = viewModel.uiState.value
+        val updatedArticle = state.articles.first { it.id == "1" }
+
+        assertEquals("Updated title", updatedArticle.title)
+        assertEquals("Updated body", updatedArticle.body)
+    }
+
+    @Test
+    fun selectArticle_updatesSelectedArticleId() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.selectArticle("2")
+
+        assertEquals("2", viewModel.uiState.value.selectedArticleId)
+    }
+
+    @Test
+    fun deleteArticle_removesArticle() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.deleteArticle("1")
+
+        val state = viewModel.uiState.value
+
+        assertEquals(false, state.articles.any { it.id == "1" })
+    }
+}
+```
+
+---
+
+## 17-2. 테스트 실행
+
+```bash
+./gradlew test
+```
+
+성공하면 commit 합니다.
+
+summary:
+
+```text
+Add ViewModel tests
+```
+
+---
+
+# 18. 15단계: Compose 화면 만들기
+
+이제 실제 화면을 만듭니다.
+
+화면은 2개입니다.
+
+```text
+ArticleListScreen
+ArticleDetailScreen
+```
+
+---
+
+## 18-1. ui 폴더 만들기
+
+```text
+app/src/main/java/com/example/viewmodelmigration/ui/
+```
+
+---
+
+## 18-2. ArticleListScreen.kt 만들기
+
+파일:
+
+```text
+ArticleListScreen.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.viewmodelmigration.core.Article
+import com.example.viewmodelmigration.core.ArticleListUiState
+
+@Composable
+fun ArticleListScreen(
+    uiState: ArticleListUiState,
+    onArticleClick: (String) -> Unit,
+    onDeleteFirstClick: () -> Unit
+) {
+    Column {
+        Button(
+            onClick = onDeleteFirstClick,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text("Delete first article")
+        }
+
+        uiState.articles.forEach { article ->
+            ArticleRow(
+                article = article,
+                onClick = {
+                    onArticleClick(article.id)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArticleRow(
+    article: Article,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(text = article.title)
+            Text(text = article.body)
+        }
+    }
+}
+```
+
+---
+
+## 18-3. ArticleDetailScreen.kt 만들기
+
+파일:
+
+```text
+ArticleDetailScreen.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.viewmodelmigration.core.Article
+
+@Composable
+fun ArticleDetailScreen(
+    article: Article,
+    onSaveClick: (Article) -> Unit,
+    onBackClick: () -> Unit
+) {
+    val titleState = remember {
+        mutableStateOf(article.title)
+    }
+
+    val bodyState = remember {
+        mutableStateOf(article.body)
+    }
+
+    Column(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Text("Edit Article")
+
+        OutlinedTextField(
+            value = titleState.value,
+            onValueChange = {
+                titleState.value = it
+            },
+            label = {
+                Text("Title")
+            }
+        )
+
+        OutlinedTextField(
+            value = bodyState.value,
+            onValueChange = {
+                bodyState.value = it
+            },
+            label = {
+                Text("Body")
+            }
+        )
+
+        Button(
+            onClick = {
+                onSaveClick(
+                    article.copy(
+                        title = titleState.value,
+                        body = bodyState.value
+                    )
+                )
+            }
+        ) {
+            Text("Save")
+        }
+
+        Button(
+            onClick = onBackClick
+        ) {
+            Text("Back")
+        }
+    }
+}
+```
+
+---
+
+# 19. 16단계: MainActivity에 화면 연결하기
+
+이제 앱을 실행했을 때 List와 Detail이 보이게 합니다.
+
+---
+
+## 19-1. MainActivity.kt 수정하기
+
+`MainActivity.kt`를 열고 아래처럼 만듭니다.
+
+패키지 이름은 프로젝트에 맞게 조정해야 합니다.
+
+```kotlin
+package com.example.viewmodelmigration
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.example.viewmodelmigration.ui.ArticleDetailScreen
+import com.example.viewmodelmigration.ui.ArticleListScreen
+import com.example.viewmodelmigration.viewmodel.ArticleListViewModel
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AppRoot()
+        }
+    }
+}
+
+@Composable
+private fun AppRoot(
+    viewModel: ArticleListViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val selectedArticleId = remember {
+        mutableStateOf<String?>(null)
+    }
+
+    val selectedArticle = uiState.articles.firstOrNull {
+        it.id == selectedArticleId.value
+    }
+
+    if (selectedArticle == null) {
+        ArticleListScreen(
+            uiState = uiState,
+            onArticleClick = { articleId ->
+                selectedArticleId.value = articleId
+                viewModel.selectArticle(articleId)
+            },
+            onDeleteFirstClick = {
+                val firstArticle = uiState.articles.firstOrNull()
+                if (firstArticle != null) {
+                    viewModel.deleteArticle(firstArticle.id)
+                }
+            }
+        )
+    } else {
+        ArticleDetailScreen(
+            article = selectedArticle,
+            onSaveClick = { updatedArticle ->
+                viewModel.updateArticle(updatedArticle)
+                selectedArticleId.value = null
+            },
+            onBackClick = {
+                selectedArticleId.value = null
+            }
+        )
+    }
+}
+```
+
+---
+
+## 19-2. 실행해서 확인하기
+
+Android Studio에서 초록색 실행 버튼 클릭.
+
+확인할 것:
+
+1. Article 목록이 보이는가?
+2. Article을 누르면 Detail 화면으로 가는가?
+3. 제목을 수정하고 Save를 누르면 List로 돌아오는가?
+4. List에서 수정된 제목이 보이는가?
+
+이 4개가 되면 이 프로젝트의 핵심 기능이 살아난 겁니다.
+
+---
+
+## 19-3. commit 하기
+
+GitHub Desktop summary:
+
+```text
+Add Compose article list and detail screens
+```
+
+Push합니다.
+
+---
+
+# 20. 17단계: 문서 작성하기
+
+코드보다 더 중요한 게 문서입니다.
+
+초보자가 봐도 이해할 수 있게 문서를 씁니다.
+
+---
+
+## 20-1. docs 폴더 구조
+
+```text
+docs/
+├─ 01-legacy-architecture.md
+├─ 02-modern-baseline.md
+├─ 03-article-state-model.md
+├─ 04-livedata-to-stateflow.md
+├─ 05-compose-ui.md
+└─ codex-for-oss.md
+```
+
+---
+
+## 20-2. `02-modern-baseline.md`
+
+내용 예시:
+
+```md
+# Modern Android Baseline
+
+This document explains why the original project was rebuilt with a modern Android baseline.
+
+## Original stack
+
+- Java
+- Support Library
+- LiveData alpha
+- DataBinding
+- Dagger 2
+- Manual Fragment transactions
+
+## Modern stack
+
+- Kotlin
+- AndroidX
+- StateFlow
+- Compose
+- ViewModel
+- GitHub Actions
+
+## Why rebuild?
+
+The original sample is valuable as a historical example, but it depends on old Android tooling.
+
+The modern sample keeps the same Article shared-state problem and rebuilds it with current Android architecture patterns.
+```
+
+---
+
+## 20-3. `03-article-state-model.md`
+
+````md
+# Article State Model
+
+The original project shared Article data between list and detail fragments.
+
+In the modern version, Article state is represented by immutable Kotlin data classes.
+
+## Article
+
+```kotlin
+data class Article(
+    val id: String,
+    val title: String,
+    val body: String
+)
+````
+
+## UI State
+
+```kotlin
+data class ArticleListUiState(
+    val articles: List<Article> = emptyList(),
+    val selectedArticleId: String? = null
+)
+```
+
+## Why immutable state?
+
+Immutable state is easier to test, easier to debug, and safer to share between screens.
+
+````
+
+---
+
+## 20-4. `04-livedata-to-stateflow.md`
+
+```md
+# LiveData to StateFlow Migration
+
+The original project used LiveData to share Article data between fragments.
+
+The modern version uses StateFlow.
+
+## Before
+
+The legacy ViewModel exposed nested LiveData:
+
+```java
+MutableLiveData<List<MutableLiveData<Article>>>
+````
+
+## After
+
+The modern ViewModel exposes one UI state stream:
+
+```kotlin
+StateFlow<ArticleListUiState>
+```
+
+## Benefit
+
+The screen observes one state object instead of many nested mutable objects.
+
+````
+
+---
+
+## 20-5. `codex-for-oss.md`
+
+```md
+# Codex for OSS Notes
+
+This repository is being prepared as an open source migration lab for legacy Android maintainers.
+
+## Why this project matters
+
+Many Android apps still contain legacy patterns such as:
+
+- Java
+- Support Library
+- early LiveData
+- DataBinding
+- Dagger 2
+- manual Fragment transactions
+
+This project provides a small, readable, tested migration path to modern Android architecture.
+
+## How Codex can help
+
+Codex can help with:
+
+- generating migration PRs
+- adding regression tests
+- updating deprecated APIs
+- reviewing architecture changes
+- maintaining documentation
+````
+
+---
+
+# 21. 18단계: PR 방식으로 작업하기
+
+지금까지는 main에 바로 commit하는 방식으로 설명했습니다.
+
+하지만 이제부터는 PR 방식으로 하는 게 좋습니다.
+
+---
+
+## 21-1. 작업 branch 만들기
+
+GitHub Desktop에서:
+
+1. branch 클릭
+2. `New Branch`
+3. 이름 입력
+
+```text
+docs/add-stateflow-migration-guide
+```
+
+4. 작업
+5. commit
+6. push
+7. GitHub에서 Pull Request 만들기
+
+---
+
+## 21-2. branch 이름 규칙
+
+| 작업 종류 | branch 이름 예시                    |
+| ----- | ------------------------------- |
+| 문서    | `docs/add-compose-guide`        |
+| 기능    | `feature/add-article-viewmodel` |
+| 테스트   | `test/add-reducer-tests`        |
+| 설정    | `build/add-ci-workflow`         |
+| 수정    | `fix/ci-build-error`            |
+
+---
+
+## 21-3. commit 메시지 규칙
+
+좋은 예:
+
+```text
+Add Article reducer tests
+```
+
+```text
+Document LiveData to StateFlow migration
+```
+
+```text
+Add Compose detail screen
+```
+
+나쁜 예:
+
+```text
+update
+```
+
+```text
+fix
+```
+
+```text
+asdf
+```
+
+---
+
+# 22. 19단계: Demo GIF 또는 스크린샷 만들기
+
+GitHub README에는 그림이 있으면 좋습니다.
+
+현재 README도 Demo 이미지를 가지고 있습니다. 
+새 프로젝트도 Demo를 넣으면 훨씬 좋아집니다.
+
+---
+
+## 22-1. 찍어야 할 장면
+
+1. 앱 실행
+2. Article 목록 보기
+3. 첫 번째 Article 클릭
+4. 제목 수정
+5. Save 클릭
+6. 목록에서 제목이 바뀐 것 확인
+
+---
+
+## 22-2. 저장 위치
+
+```text
+docs/images/demo.gif
+```
+
+README에 추가:
+
+```md
+## Demo
+
+![Demo](docs/images/demo.gif)
+```
+
+---
+
+## 22-3. commit 하기
+
+summary:
+
+```text
+Add demo GIF
+```
+
+---
+
+# 23. 20단계: 첫 번째 release 만들기
+
+어느 정도 준비되면 release를 만듭니다.
+
+---
+
+## 23-1. GitHub에서 release 만들기
+
+1. GitHub repository 접속
+2. 오른쪽 `Releases`
+3. `Create a new release`
+4. Tag 입력
+
+```text
+v0.1.0-modern-baseline
+```
+
+5. 제목 입력
+
+```text
+v0.1.0 - Modern Android Baseline
+```
+
+6. 설명 입력
+
+```md
+## What's included
+
+- Rebranded project as Android ViewModel Migration Lab
+- Preserved 2017 legacy baseline
+- Added modern Android project baseline
+- Added Article domain model
+- Added StateFlow ViewModel
+- Added reducer and ViewModel tests
+- Added migration documentation
+```
+
+7. Publish
+
+---
+
+# 24. 21단계: Codex for OSS 제출 전 체크리스트
+
+아래가 모두 체크되어야 제출할 만합니다.
+
+```md
+## Repository
+
+- [ ] Repository is public
+- [ ] Repository name is clear
+- [ ] Repository description is clear
+- [ ] README explains the project
+- [ ] LICENSE exists
+- [ ] CONTRIBUTING.md exists
+- [ ] SECURITY.md exists
+
+## Code
+
+- [ ] Modern Android app builds
+- [ ] Article model exists
+- [ ] ViewModel exists
+- [ ] StateFlow is used
+- [ ] Compose screens exist
+- [ ] Tests exist
+
+## CI
+
+- [ ] GitHub Actions runs on push
+- [ ] GitHub Actions runs on PR
+- [ ] Tests pass
+- [ ] Debug build passes
+
+## Documentation
+
+- [ ] Legacy architecture guide exists
+- [ ] Modern baseline guide exists
+- [ ] LiveData to StateFlow guide exists
+- [ ] Compose guide exists
+- [ ] Codex for OSS notes exist
+
+## Project activity
+
+- [ ] Issues exist
+- [ ] Pull requests exist
+- [ ] At least one release exists
+- [ ] Demo GIF or screenshots exist
+```
+
+---
+
+# 25. 가장 추천하는 실제 작업 순서
+
+아래 순서대로 하면 됩니다.
+
+## 첫날: 저장소 정리
+
+```text
+1. GitHub Desktop 설치
+2. repo clone
+3. legacy/2017-original branch 만들기
+4. v0.0.0-legacy-2017 tag 만들기
+5. main branch 만들기
+6. README 새로 쓰기
+7. LICENSE 추가
+8. CONTRIBUTING.md 추가
+9. SECURITY.md 추가
+10. Push
+```
+
+완료 목표:
+
+```text
+GitHub 첫 화면이 오픈소스 프로젝트처럼 보이기
+```
+
+---
+
+## 둘째 날: 최신 Android 뼈대 만들기
+
+```text
+1. Android Studio에서 새 Kotlin Android 프로젝트 만들기
+2. 새 프로젝트가 실행되는지 확인
+3. 기존 repo에 새 app 구조 복사
+4. legacy-app 폴더로 옛 app 보관
+5. ./gradlew assembleDebug 실행
+6. GitHub Actions CI 추가
+7. Push
+```
+
+완료 목표:
+
+```text
+GitHub Actions에서 BUILD SUCCESSFUL 보기
+```
+
+---
+
+## 셋째 날: Article 상태 만들기
+
+```text
+1. Article.kt 만들기
+2. SampleArticles.kt 만들기
+3. ArticleListUiState.kt 만들기
+4. ArticleListAction.kt 만들기
+5. ArticleListReducer.kt 만들기
+6. Reducer 테스트 만들기
+7. ./gradlew test 실행
+8. Push
+```
+
+완료 목표:
+
+```text
+글 수정/삭제/선택 테스트 통과
+```
+
+---
+
+## 넷째 날: ViewModel 만들기
+
+```text
+1. ArticleListViewModel.kt 만들기
+2. StateFlow로 uiState 만들기
+3. selectArticle 함수 만들기
+4. updateArticle 함수 만들기
+5. deleteArticle 함수 만들기
+6. ViewModel 테스트 만들기
+7. ./gradlew test 실행
+8. Push
+```
+
+완료 목표:
+
+```text
+ViewModel 테스트 통과
+```
+
+---
+
+## 다섯째 날: 화면 만들기
+
+```text
+1. ArticleListScreen.kt 만들기
+2. ArticleDetailScreen.kt 만들기
+3. MainActivity에 화면 연결
+4. 앱 실행
+5. 글 클릭
+6. 제목 수정
+7. Save
+8. 목록에서 수정 확인
+9. Push
+```
+
+완료 목표:
+
+```text
+앱에서 실제로 수정이 반영되는 것 확인
+```
+
+---
+
+## 여섯째 날: 문서 만들기
+
+```text
+1. docs/02-modern-baseline.md 작성
+2. docs/03-article-state-model.md 작성
+3. docs/04-livedata-to-stateflow.md 작성
+4. docs/05-compose-ui.md 작성
+5. docs/codex-for-oss.md 작성
+6. README에 문서 링크 추가
+7. Push
+```
+
+완료 목표:
+
+```text
+코드를 모르는 사람도 README와 docs를 보고 이해 가능
+```
+
+---
+
+## 일곱째 날: 제출 준비
+
+```text
+1. Demo GIF 만들기
+2. README에 Demo 추가
+3. GitHub Issues 정리
+4. v0.1.0 release 만들기
+5. Codex for OSS 신청 문구 준비
+```
+
+완료 목표:
+
+```text
+Codex for OSS 폼에 넣을 수 있는 상태 만들기
+```
+
+---
+
+# 26. Codex for OSS 제출 문구
+
+## Repository 설명
+
+```text
+A practical migration lab for modernizing legacy Android ViewModel and LiveData apps.
+```
+
+## Why does this repository qualify?
+
+```text
+This project helps maintainers modernize legacy Android apps built with Java, Support Library, early LiveData/ViewModel, DataBinding, Dagger 2, and manual Fragment navigation. It provides runnable before/after samples, tests, and step-by-step migration guides to AndroidX, Kotlin, StateFlow, Hilt, Navigation, and Compose.
+```
+
+## How will you use Codex?
+
+```text
+We will use Codex to generate migration PRs, add regression tests, review architecture changes, update deprecated Android APIs, maintain documentation, and validate before/after examples for legacy Android modernization workflows.
+```
+
+---
+
+# 27. 실수했을 때 대처법
+
+## 빌드 실패
+
+터미널에 빨간 글씨가 나오면 당황하지 말고 아래를 봅니다.
+
+| 에러 느낌                  | 뜻                     | 대처                        |
+| ---------------------- | --------------------- | ------------------------- |
+| `Unresolved reference` | 이름을 못 찾음              | import 또는 파일 이름 확인        |
+| `Build failed`         | 앱 조립 실패               | 에러 첫 번째 줄 확인              |
+| `Package name` 관련 에러   | 폴더 위치와 package 이름 불일치 | package 경로 확인             |
+| `Gradle sync failed`   | Gradle 설정 문제          | Android Studio Sync 다시 실행 |
+| `Test failed`          | 테스트 결과가 예상과 다름        | expected / actual 비교      |
+
+---
+
+## GitHub Desktop에서 변경이 너무 많을 때
+
+무서워하지 말고:
+
+1. 바꾼 파일 목록 보기
+2. 내가 만든 파일인지 확인
+3. 이상한 파일이면 체크 해제
+4. commit 메시지 정확히 쓰기
+
+---
+
+## main에 직접 큰 실수를 올렸을 때
+
+바로 고치려고 하지 말고:
+
+1. GitHub Desktop에서 History 보기
+2. 마지막 정상 commit 확인
+3. 문제가 된 파일만 되돌리기
+4. 새 commit으로 수정
+
+---
+
+# 28. 최종 목표 모습
+
+마지막에는 repository가 이런 모습이면 좋습니다.
+
+```text
+android-viewmodel-migration-lab/
+├─ README.md
+├─ LICENSE
+├─ CONTRIBUTING.md
+├─ SECURITY.md
+├─ app/
+│  └─ modern Android sample
+├─ legacy-app/
+│  └─ original 2017 sample
+├─ docs/
+│  ├─ 01-legacy-architecture.md
+│  ├─ 02-modern-baseline.md
+│  ├─ 03-article-state-model.md
+│  ├─ 04-livedata-to-stateflow.md
+│  ├─ 05-compose-ui.md
+│  └─ codex-for-oss.md
+├─ .github/
+│  ├─ workflows/
+│  │  └─ android.yml
+│  └─ pull_request_template.md
+└─ gradle/
+```
+
+GitHub 첫 화면에서는 이렇게 보여야 합니다.
+
+```text
+Android ViewModel Migration Lab
+
+A practical migration lab for maintainers of legacy Android apps.
+
+- Original 2017 Android AAC sample preserved
+- Modern Android version added
+- Article shared-state problem explained
+- StateFlow ViewModel implemented
+- Tests included
+- Migration docs included
+```
+
+---
+
+# 29. 제일 먼저 해야 하는 것만 다시 정리
+
+지금 바로 시작한다면 이 순서입니다.
+
+```text
+1. GitHub Desktop으로 repo clone
+2. legacy/2017-original branch 만들기
+3. v0.0.0-legacy-2017 tag 만들기
+4. main branch 만들기
+5. README 새로 쓰기
+6. LICENSE 추가
+7. CONTRIBUTING.md 추가
+8. GitHub Issues 만들기
+9. Android Studio에서 새 Kotlin Android 프로젝트 만들기
+10. 새 프로젝트를 기존 repo에 옮기기
+```
+
+이 10개가 끝나면 프로젝트 방향이 완전히 바뀝니다.
+
+핵심은 이것입니다.
+
+> **코드를 완벽히 이해하고 시작하는 게 아니라,
+> 작은 단계로 만들고, 실행하고, 저장하면서 배우는 방식으로 진행하면 됩니다.**
+
+[1]: https://developer.android.com/topic/libraries/architecture/viewmodel "ViewModel overview  |  App architecture  |  Android Developers"
+[2]: https://openai.com/form/codex-for-oss "Codex for Open Source | OpenAI"

--- a/docs/oss-remake-task-plan.md
+++ b/docs/oss-remake-task-plan.md
@@ -1,0 +1,2324 @@
+# Android ViewModel Migration Lab OSS 리메이크 태스크 플랜
+
+## 0. 문서 목적
+
+이 문서는 `Android-AAC-ViewModel-Practice` 저장소를 **초보자 친화형 Android OSS 마이그레이션 랩**으로 리메이크하기 위한 실행 계획서입니다.
+
+이 계획서는 아래 사람도 따라 할 수 있도록 작성되었습니다.
+
+- Android 개발 경험이 적은 사람
+- GitHub 사용이 익숙하지 않은 사람
+- Kotlin, Compose, ViewModel, StateFlow를 처음 접하는 사람
+- 기존 레거시 Android 프로젝트를 최신 구조로 바꾸는 과정을 배우고 싶은 사람
+
+이 문서의 핵심 원칙은 다음과 같습니다.
+
+> 한 번에 크게 바꾸지 않는다.  
+> 작은 단위로 바꾸고, 테스트하고, 커밋하고, 문서화한다.
+
+---
+
+## 1. 프로젝트 정체성
+
+### 1.1 이 프로젝트가 아닌 것
+
+이 프로젝트는 Reserve.M 프로젝트가 아닙니다.
+
+따라서 아래 용어와 방향은 사용하지 않습니다.
+
+- Reserve.M
+- 예약
+- 매출
+- 고객 관리
+- お客様
+- 予約
+- 売上
+- ダブルブッキング
+- 稼働率改善
+- 失客防止
+- リピート率向上
+
+이 프로젝트는 특정 비즈니스 앱을 홍보하거나 재현하는 저장소가 아닙니다.
+
+---
+
+### 1.2 이 프로젝트가 되는 것
+
+이 프로젝트는 아래 주제를 다룹니다.
+
+> 오래된 Android AAC / ViewModel 공유 상태 샘플을  
+> Kotlin, Compose, ViewModel, StateFlow 기반의 현대 Android 구조로 재구성하는  
+> 초보자 친화형 OSS 마이그레이션 랩
+
+핵심 예제 도메인은 `Article`입니다.
+
+앱의 핵심 흐름은 다음과 같습니다.
+
+```text
+Article List
+↓
+Article Detail
+↓
+Edit Article
+↓
+Save
+↓
+Back to List
+↓
+Updated Article is reflected
+```
+
+한국어로 말하면 다음과 같습니다.
+
+```text
+글 목록 보기
+↓
+글 상세 보기
+↓
+글 수정하기
+↓
+저장하기
+↓
+목록으로 돌아가기
+↓
+수정된 글이 목록에 반영되었는지 확인하기
+```
+
+---
+
+## 2. 최종 목표
+
+### 2.1 한 문장 목표
+
+```text
+A beginner-friendly OSS migration lab that modernizes a 2017 Android AAC ViewModel shared-state sample with Kotlin, Compose, ViewModel, and StateFlow.
+```
+
+한국어 설명:
+
+```text
+2017년식 Android AAC ViewModel 공유 상태 예제를 Kotlin, Compose, ViewModel, StateFlow 기반의 현대 Android 구조로 바꾸는 초보자 친화형 OSS 마이그레이션 학습 프로젝트입니다.
+```
+
+---
+
+### 2.2 기술 선택
+
+1차 리메이크에서는 선택지를 늘리지 않습니다. 아래로 고정합니다.
+
+| 항목 | 선택 |
+|---|---|
+| 언어 | Kotlin |
+| UI | Jetpack Compose |
+| 상태관리 | ViewModel + StateFlow |
+| DI | 1차 제외 |
+| Navigation | 별도 라이브러리 없이 간단한 상태 전환 |
+| 테스트 | Reducer 테스트 + ViewModel 테스트 |
+| Legacy 보존 | branch, tag, `legacy-app/` |
+| CI 빌드 대상 | 현대 `app/` 모듈만 |
+
+---
+
+## 3. 최종 산출 기준
+
+아래 조건을 모두 만족하면 `v0.1.0-oss-alpha.1`을 만들 수 있습니다.
+
+### 3.1 저장소 구조
+
+- [ ] 원본 상태를 보존한 `legacy/2017-original` branch가 존재한다.
+- [ ] 원본 상태를 가리키는 `v0.0.0-legacy-2017` tag가 존재한다.
+- [ ] 기존 Android 앱 코드는 `legacy-app/`에 읽기용 아카이브로 보존되어 있다.
+- [ ] 현대 Android 앱은 `app/`에 존재한다.
+- [ ] 1차 CI 빌드 대상은 `app/` 하나뿐이다.
+
+---
+
+### 3.2 OSS 기본 파일
+
+아래 파일이 존재해야 합니다.
+
+```text
+README.md
+LICENSE
+CONTRIBUTING.md
+SECURITY.md
+CODE_OF_CONDUCT.md
+CHANGELOG.md
+.github/pull_request_template.md
+.github/ISSUE_TEMPLATE/bug_report.md
+.github/ISSUE_TEMPLATE/migration_task.md
+.github/workflows/android.yml
+```
+
+---
+
+### 3.3 앱 기능
+
+아래 흐름이 실제 앱에서 동작해야 합니다.
+
+```text
+Article List → Article Detail → Edit → Save → List 반영
+```
+
+확인할 동작:
+
+- [ ] Article 목록이 보인다.
+- [ ] Article을 누르면 상세 화면으로 이동한다.
+- [ ] 제목과 본문을 수정할 수 있다.
+- [ ] Save를 누르면 목록 화면으로 돌아온다.
+- [ ] 목록에서 수정된 내용이 보인다.
+- [ ] Article을 삭제할 수 있다.
+- [ ] 선택된 Article을 삭제하면 선택 상태가 초기화된다.
+
+---
+
+### 3.4 테스트
+
+아래 테스트가 통과해야 합니다.
+
+- [ ] Article 선택 시 `selectedArticleId`가 변경된다.
+- [ ] Article 수정 시 목록의 해당 Article이 변경된다.
+- [ ] Article 삭제 시 목록에서 제거된다.
+- [ ] 선택된 Article 삭제 시 `selectedArticleId`가 `null`이 된다.
+- [ ] ViewModel이 StateFlow로 최신 UI 상태를 노출한다.
+
+명령어:
+
+```bash
+./gradlew test
+```
+
+Windows:
+
+```bash
+gradlew.bat test
+```
+
+---
+
+### 3.5 CI
+
+GitHub Actions에서 아래 명령어가 통과해야 합니다.
+
+```bash
+./gradlew test
+./gradlew assembleDebug
+```
+
+---
+
+### 3.6 문서
+
+아래 문서가 존재해야 합니다.
+
+```text
+docs/01-legacy-architecture.md
+docs/02-modern-architecture.md
+docs/03-shared-state-problem.md
+docs/04-livedata-to-stateflow.md
+docs/05-compose-ui.md
+docs/codex-for-oss.md
+```
+
+---
+
+### 3.7 릴리스
+
+아래 태그가 존재해야 합니다.
+
+```text
+v0.1.0-oss-alpha.1
+```
+
+그리고 GitHub Release에 릴리스 노트가 있어야 합니다.
+
+---
+
+## 4. 권장 최종 저장소 구조
+
+최종적으로 저장소는 아래 구조를 목표로 합니다.
+
+```text
+android-viewmodel-migration-lab/
+├─ README.md
+├─ LICENSE
+├─ CONTRIBUTING.md
+├─ SECURITY.md
+├─ CODE_OF_CONDUCT.md
+├─ CHANGELOG.md
+├─ settings.gradle.kts
+├─ build.gradle.kts
+├─ gradlew
+├─ gradlew.bat
+├─ gradle/
+├─ app/
+│  └─ modern Kotlin + Compose Android app
+├─ legacy-app/
+│  └─ original 2017 Android AAC sample, archive only
+├─ docs/
+│  ├─ 01-legacy-architecture.md
+│  ├─ 02-modern-architecture.md
+│  ├─ 03-shared-state-problem.md
+│  ├─ 04-livedata-to-stateflow.md
+│  ├─ 05-compose-ui.md
+│  └─ codex-for-oss.md
+└─ .github/
+   ├─ pull_request_template.md
+   ├─ ISSUE_TEMPLATE/
+   │  ├─ bug_report.md
+   │  └─ migration_task.md
+   └─ workflows/
+      └─ android.yml
+```
+
+중요:
+
+```text
+legacy-app/는 읽기용입니다.
+1차 단계에서 legacy-app/는 빌드하지 않습니다.
+현대 앱의 빌드 대상은 app/ 하나입니다.
+```
+
+`settings.gradle.kts`에는 1차에서 아래처럼 `:app`만 포함합니다.
+
+```kotlin
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "AndroidViewModelMigrationLab"
+include(":app")
+```
+
+---
+
+## 5. 전체 실행 순서 요약
+
+작업은 아래 순서로 진행합니다.
+
+```text
+0단계: 목표 정리 및 원본 보존
+1단계: OSS 메타/가이드 기본 구성
+2단계: 현대 Android 앱 뼈대 정비
+3단계: 도메인/상태 모델 정리
+4단계: 테스트 기반 완성
+5단계: ViewModel/화면 구현
+6단계: CI/문서/릴리스
+```
+
+진행 원칙:
+
+```text
+작은 작업
+→ 로컬 확인
+→ 테스트
+→ 커밋
+→ Push
+→ 다음 작업
+```
+
+---
+
+## 6. 0단계: 목표 정리 및 원본 보존
+
+### 6.1 목적
+
+원본 프로젝트를 잃어버리지 않도록 안전하게 보존합니다.
+
+리메이크를 진행하다가 실수해도 언제든 원본으로 돌아갈 수 있어야 합니다.
+
+---
+
+### 6.2 할 일
+
+#### 6.2.1 저장소 clone
+
+GitHub Desktop 또는 터미널로 저장소를 가져옵니다.
+
+```bash
+git clone https://github.com/leesunghyun/Android-AAC-ViewModel-Practice.git
+cd Android-AAC-ViewModel-Practice
+```
+
+---
+
+#### 6.2.2 원본 branch 생성
+
+```bash
+git checkout master
+git checkout -b legacy/2017-original
+git push origin legacy/2017-original
+```
+
+주의:
+
+- 기본 branch가 `master`가 아니라면 현재 기본 branch 이름을 사용합니다.
+- GitHub Desktop을 사용한다면 `New Branch` 버튼으로 만들어도 됩니다.
+
+---
+
+#### 6.2.3 원본 tag 생성
+
+```bash
+git checkout legacy/2017-original
+git tag v0.0.0-legacy-2017
+git push origin v0.0.0-legacy-2017
+```
+
+뜻:
+
+```text
+v0.0.0-legacy-2017
+= 리메이크 전 원본을 고정해두는 이름표
+```
+
+---
+
+#### 6.2.4 main branch 생성
+
+```bash
+git checkout master
+git checkout -b main
+git push origin main
+```
+
+GitHub repository 설정에서 기본 branch를 `main`으로 변경합니다.
+
+경로:
+
+```text
+GitHub repository
+→ Settings
+→ Branches
+→ Default branch
+→ main
+```
+
+---
+
+#### 6.2.5 기존 README 보존
+
+기존 `README.md` 내용을 아래 파일로 이동합니다.
+
+```text
+docs/01-legacy-architecture.md
+```
+
+파일 맨 위에는 아래 제목을 넣습니다.
+
+```md
+# 2017 Legacy Architecture
+```
+
+---
+
+### 6.3 완료 기준
+
+- [ ] `legacy/2017-original` branch가 GitHub에 있다.
+- [ ] `v0.0.0-legacy-2017` tag가 GitHub에 있다.
+- [ ] `main` branch가 기본 branch다.
+- [ ] 기존 README가 `docs/01-legacy-architecture.md`에 보존되어 있다.
+
+---
+
+### 6.4 추천 커밋 메시지
+
+```text
+Preserve original 2017 legacy baseline
+```
+
+---
+
+## 7. 1단계: OSS 메타/가이드 기본 구성
+
+### 7.1 목적
+
+저장소를 오픈소스 프로젝트처럼 보이게 만드는 단계입니다.
+
+코드보다 먼저 해야 합니다.  
+왜냐하면 처음 방문한 사람이 README를 보고 프로젝트의 목적을 이해해야 하기 때문입니다.
+
+---
+
+### 7.2 README.md 재작성
+
+루트의 `README.md`를 새로 작성합니다.
+
+권장 첫 문장:
+
+```md
+# Android ViewModel Migration Lab
+
+A beginner-friendly OSS migration lab that modernizes a 2017 Android AAC ViewModel shared-state sample with Kotlin, Compose, ViewModel, and StateFlow.
+```
+
+README에는 최소한 아래 섹션을 넣습니다.
+
+```md
+## What this project teaches
+
+## Original problem
+
+## Modern solution
+
+## Quick start
+
+## Project structure
+
+## Migration docs
+
+## Roadmap
+
+## Contributing
+
+## License
+```
+
+---
+
+### 7.3 LICENSE 추가
+
+추천 라이선스:
+
+```text
+Apache-2.0
+```
+
+GitHub에서 만드는 방법:
+
+```text
+Add file
+→ Create new file
+→ LICENSE
+→ Choose a license template
+→ Apache License 2.0
+```
+
+---
+
+### 7.4 CONTRIBUTING.md 추가
+
+파일:
+
+```text
+CONTRIBUTING.md
+```
+
+권장 내용:
+
+```md
+# Contributing
+
+Thank you for your interest in contributing.
+
+This project is a beginner-friendly migration lab for legacy Android architecture.
+
+## How to contribute
+
+1. Pick a small issue.
+2. Create a small branch.
+3. Make one focused change.
+4. Run tests.
+5. Open a pull request.
+
+## Rules
+
+- Keep each pull request small.
+- Do not mix unrelated changes.
+- Prefer readable code over clever code.
+- Update documentation when behavior changes.
+```
+
+---
+
+### 7.5 SECURITY.md 추가
+
+파일:
+
+```text
+SECURITY.md
+```
+
+권장 내용:
+
+```md
+# Security Policy
+
+This project is an educational Android migration sample.
+
+Do not include secrets, API keys, private credentials, or personal data in issues or pull requests.
+
+If you find a security issue in sample code or documentation, please open an issue with a clear explanation.
+```
+
+---
+
+### 7.6 CODE_OF_CONDUCT.md 추가
+
+파일:
+
+```text
+CODE_OF_CONDUCT.md
+```
+
+권장 내용:
+
+```md
+# Code of Conduct
+
+This project is intended to be a friendly learning space.
+
+Please be respectful, patient, and constructive when opening issues, reviewing pull requests, or asking questions.
+```
+
+---
+
+### 7.7 Pull Request 템플릿 추가
+
+파일:
+
+```text
+.github/pull_request_template.md
+```
+
+내용:
+
+```md
+## Summary
+
+Explain what changed.
+
+## Migration step
+
+- [ ] Documentation
+- [ ] Build / Gradle
+- [ ] Domain model
+- [ ] Reducer
+- [ ] ViewModel
+- [ ] Compose UI
+- [ ] Tests
+- [ ] CI
+
+## How I tested this
+
+- [ ] I ran `./gradlew test`
+- [ ] I ran `./gradlew assembleDebug`
+- [ ] I checked the app manually
+
+## Notes
+
+Write any failure reason, known issue, or follow-up task here.
+```
+
+---
+
+### 7.8 Issue 템플릿 추가
+
+폴더:
+
+```text
+.github/ISSUE_TEMPLATE/
+```
+
+파일 1:
+
+```text
+.github/ISSUE_TEMPLATE/bug_report.md
+```
+
+내용:
+
+```md
+# Bug Report
+
+## What happened?
+
+Describe the problem.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected result
+
+What should have happened?
+
+## Actual result
+
+What happened instead?
+
+## Environment
+
+- OS:
+- Android Studio version:
+- JDK version:
+- Device or emulator:
+
+## Logs or screenshots
+
+Paste logs or screenshots if available.
+```
+
+파일 2:
+
+```text
+.github/ISSUE_TEMPLATE/migration_task.md
+```
+
+내용:
+
+```md
+# Migration Task
+
+## Goal
+
+What migration step does this issue cover?
+
+## Tasks
+
+- [ ]
+- [ ]
+- [ ]
+
+## Done when
+
+- [ ] Code is updated
+- [ ] Tests pass
+- [ ] Documentation is updated
+```
+
+---
+
+### 7.9 CHANGELOG.md 추가
+
+파일:
+
+```text
+CHANGELOG.md
+```
+
+초기 내용:
+
+```md
+# Changelog
+
+## v0.1.0-oss-alpha.1
+
+### Added
+- Modern Kotlin + Compose app baseline
+- Article shared-state sample
+- ViewModel + StateFlow state management
+- Article reducer
+- Reducer tests
+- ViewModel tests
+- Beginner-friendly migration documentation
+
+### Preserved
+- Original 2017 Android AAC ViewModel sample as legacy archive
+```
+
+---
+
+### 7.10 완료 기준
+
+- [ ] README가 새 프로젝트 목적을 설명한다.
+- [ ] LICENSE가 있다.
+- [ ] CONTRIBUTING.md가 있다.
+- [ ] SECURITY.md가 있다.
+- [ ] CODE_OF_CONDUCT.md가 있다.
+- [ ] CHANGELOG.md가 있다.
+- [ ] PR 템플릿이 있다.
+- [ ] Issue 템플릿이 있다.
+
+---
+
+### 7.11 추천 커밋 메시지
+
+```text
+Add OSS project metadata and contribution guides
+```
+
+---
+
+## 8. 2단계: 현대 Android 앱 뼈대 정비
+
+### 8.1 목적
+
+오래된 Gradle과 Android 설정을 억지로 업그레이드하지 않습니다.
+
+대신 새 Kotlin + Compose 앱을 만들고, 기존 원본은 `legacy-app/`에 읽기용으로 보존합니다.
+
+---
+
+### 8.2 중요한 원칙
+
+```text
+기존 오래된 Gradle 설정을 직접 고치려고 하지 않는다.
+새로운 Android Studio 프로젝트를 기준으로 현대 앱 뼈대를 만든다.
+legacy-app/는 빌드 대상이 아니다.
+app/만 빌드한다.
+```
+
+---
+
+### 8.3 작업 순서
+
+#### 8.3.1 Android Studio에서 새 프로젝트 생성
+
+Android Studio에서:
+
+```text
+File
+→ New
+→ New Project
+→ Empty Activity 또는 Empty Compose Activity
+```
+
+설정:
+
+```text
+Name: AndroidViewModelMigrationLab
+Language: Kotlin
+UI: Compose
+Minimum SDK: 기본값 사용
+```
+
+---
+
+#### 8.3.2 새 프로젝트 단독 실행 확인
+
+새 프로젝트에서 아래를 확인합니다.
+
+```bash
+./gradlew test
+./gradlew assembleDebug
+```
+
+또는 Android Studio의 Run 버튼으로 실행합니다.
+
+---
+
+#### 8.3.3 기존 app을 legacy-app으로 이동
+
+기존 저장소에서:
+
+```text
+app/
+↓
+legacy-app/
+```
+
+주의:
+
+```text
+legacy-app/는 1차 단계에서 빌드하지 않습니다.
+legacy-app/는 원본 참고용입니다.
+```
+
+---
+
+#### 8.3.4 새 app을 복사
+
+새 Android Studio 프로젝트에서 아래 항목을 기존 저장소로 복사합니다.
+
+```text
+app/
+settings.gradle.kts
+build.gradle.kts
+gradle/
+gradlew
+gradlew.bat
+```
+
+---
+
+#### 8.3.5 settings.gradle.kts 확인
+
+1차에서는 아래처럼 `:app`만 포함합니다.
+
+```kotlin
+rootProject.name = "AndroidViewModelMigrationLab"
+include(":app")
+```
+
+`legacy-app`는 넣지 않습니다.
+
+---
+
+#### 8.3.6 로컬 빌드 확인
+
+macOS 또는 Linux:
+
+```bash
+./gradlew test
+./gradlew assembleDebug
+```
+
+Windows:
+
+```bash
+gradlew.bat test
+gradlew.bat assembleDebug
+```
+
+성공 메시지:
+
+```text
+BUILD SUCCESSFUL
+```
+
+---
+
+### 8.4 완료 기준
+
+- [ ] `legacy-app/`에 원본 코드가 있다.
+- [ ] `app/`에 새 Kotlin + Compose 앱이 있다.
+- [ ] `settings.gradle.kts`에는 `:app`만 포함된다.
+- [ ] `./gradlew test`가 통과한다.
+- [ ] `./gradlew assembleDebug`가 통과한다.
+
+---
+
+### 8.5 추천 커밋 메시지
+
+```text
+Add modern Android app baseline
+```
+
+---
+
+## 9. 3단계: 도메인/상태 모델 정리
+
+### 9.1 목적
+
+화면 없이도 핵심 로직을 테스트할 수 있도록 도메인과 상태 모델을 분리합니다.
+
+중요한 점:
+
+```text
+Article은 글 하나입니다.
+ArticleListUiState는 목록 화면 전체 상태입니다.
+```
+
+---
+
+### 9.2 만들 파일
+
+권장 패키지:
+
+```text
+app/src/main/java/com/example/viewmodelmigration/core/
+```
+
+파일:
+
+```text
+Article.kt
+SampleArticles.kt
+ArticleListUiState.kt
+ArticleListAction.kt
+ArticleListReducer.kt
+```
+
+---
+
+### 9.3 Article.kt
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+data class Article(
+    val id: String,
+    val title: String,
+    val body: String
+)
+```
+
+---
+
+### 9.4 SampleArticles.kt
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+object SampleArticles {
+    fun create(): List<Article> {
+        return listOf(
+            Article(
+                id = "1",
+                title = "Legacy ViewModel",
+                body = "This article explains the original 2017 ViewModel idea."
+            ),
+            Article(
+                id = "2",
+                title = "StateFlow Migration",
+                body = "This article explains how to migrate LiveData to StateFlow."
+            ),
+            Article(
+                id = "3",
+                title = "Compose UI",
+                body = "This article explains how to render state with Compose."
+            )
+        )
+    }
+}
+```
+
+---
+
+### 9.5 ArticleListUiState.kt
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+data class ArticleListUiState(
+    val articles: List<Article> = emptyList(),
+    val selectedArticleId: String? = null
+)
+```
+
+---
+
+### 9.6 ArticleListAction.kt
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+sealed interface ArticleListAction {
+    data class SelectArticle(val articleId: String) : ArticleListAction
+    data class UpdateArticle(val article: Article) : ArticleListAction
+    data class DeleteArticle(val articleId: String) : ArticleListAction
+}
+```
+
+---
+
+### 9.7 ArticleListReducer.kt
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+object ArticleListReducer {
+
+    fun reduce(
+        state: ArticleListUiState,
+        action: ArticleListAction
+    ): ArticleListUiState {
+        return when (action) {
+            is ArticleListAction.SelectArticle -> {
+                state.copy(
+                    selectedArticleId = action.articleId
+                )
+            }
+
+            is ArticleListAction.UpdateArticle -> {
+                state.copy(
+                    articles = state.articles.map { article ->
+                        if (article.id == action.article.id) {
+                            action.article
+                        } else {
+                            article
+                        }
+                    }
+                )
+            }
+
+            is ArticleListAction.DeleteArticle -> {
+                state.copy(
+                    articles = state.articles.filterNot { article ->
+                        article.id == action.articleId
+                    },
+                    selectedArticleId = if (state.selectedArticleId == action.articleId) {
+                        null
+                    } else {
+                        state.selectedArticleId
+                    }
+                )
+            }
+        }
+    }
+}
+```
+
+---
+
+### 9.8 완료 기준
+
+- [ ] `Article` 모델이 있다.
+- [ ] `SampleArticles`가 있다.
+- [ ] `ArticleListUiState`가 있다.
+- [ ] `ArticleListAction`이 있다.
+- [ ] `ArticleListReducer`가 있다.
+- [ ] Android 화면 없이 상태 변경 로직을 테스트할 수 있다.
+
+---
+
+### 9.9 추천 커밋 메시지
+
+```text
+Add Article state model and reducer
+```
+
+---
+
+## 10. 4단계: 테스트 기반 완성
+
+### 10.1 목적
+
+앱을 실행하지 않아도 핵심 로직이 맞는지 확인합니다.
+
+테스트는 자동 채점기입니다.
+
+---
+
+### 10.2 만들 파일
+
+권장 패키지:
+
+```text
+app/src/test/java/com/example/viewmodelmigration/core/
+```
+
+파일:
+
+```text
+ArticleListReducerTest.kt
+```
+
+---
+
+### 10.3 ArticleListReducerTest.kt
+
+```kotlin
+package com.example.viewmodelmigration.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ArticleListReducerTest {
+
+    @Test
+    fun selectArticle_updatesSelectedArticleId() {
+        val oldState = ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.SelectArticle("2")
+        )
+
+        assertEquals("2", newState.selectedArticleId)
+    }
+
+    @Test
+    fun updateArticle_updatesArticleInList() {
+        val oldArticle = Article(
+            id = "1",
+            title = "Old title",
+            body = "Old body"
+        )
+
+        val updatedArticle = Article(
+            id = "1",
+            title = "New title",
+            body = "New body"
+        )
+
+        val oldState = ArticleListUiState(
+            articles = listOf(oldArticle)
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.UpdateArticle(updatedArticle)
+        )
+
+        assertEquals("New title", newState.articles.first().title)
+        assertEquals("New body", newState.articles.first().body)
+    }
+
+    @Test
+    fun deleteArticle_removesArticleFromList() {
+        val oldState = ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.DeleteArticle("1")
+        )
+
+        assertEquals(false, newState.articles.any { article ->
+            article.id == "1"
+        })
+    }
+
+    @Test
+    fun deleteSelectedArticle_clearsSelectedArticleId() {
+        val oldState = ArticleListUiState(
+            articles = SampleArticles.create(),
+            selectedArticleId = "1"
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.DeleteArticle("1")
+        )
+
+        assertNull(newState.selectedArticleId)
+    }
+}
+```
+
+---
+
+### 10.4 테스트 실행
+
+macOS 또는 Linux:
+
+```bash
+./gradlew test
+```
+
+Windows:
+
+```bash
+gradlew.bat test
+```
+
+---
+
+### 10.5 완료 기준
+
+- [ ] Article 선택 테스트가 통과한다.
+- [ ] Article 수정 테스트가 통과한다.
+- [ ] Article 삭제 테스트가 통과한다.
+- [ ] 선택된 Article 삭제 테스트가 통과한다.
+- [ ] `./gradlew test`가 성공한다.
+
+---
+
+### 10.6 추천 커밋 메시지
+
+```text
+Add reducer tests for Article state updates
+```
+
+---
+
+## 11. 5단계: ViewModel 구현
+
+### 11.1 목적
+
+화면이 사용할 상태를 ViewModel에서 제공합니다.
+
+ViewModel은 아래 역할을 합니다.
+
+```text
+현재 UI 상태를 StateFlow로 제공한다.
+사용자의 행동을 Action으로 바꾼다.
+Reducer를 사용해서 상태를 업데이트한다.
+```
+
+---
+
+### 11.2 만들 파일
+
+권장 패키지:
+
+```text
+app/src/main/java/com/example/viewmodelmigration/viewmodel/
+```
+
+파일:
+
+```text
+ArticleListViewModel.kt
+```
+
+---
+
+### 11.3 ArticleListViewModel.kt
+
+```kotlin
+package com.example.viewmodelmigration.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.example.viewmodelmigration.core.Article
+import com.example.viewmodelmigration.core.ArticleListAction
+import com.example.viewmodelmigration.core.ArticleListReducer
+import com.example.viewmodelmigration.core.ArticleListUiState
+import com.example.viewmodelmigration.core.SampleArticles
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class ArticleListViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+    )
+
+    val uiState: StateFlow<ArticleListUiState> = _uiState.asStateFlow()
+
+    fun selectArticle(articleId: String) {
+        dispatch(ArticleListAction.SelectArticle(articleId))
+    }
+
+    fun updateArticle(article: Article) {
+        dispatch(ArticleListAction.UpdateArticle(article))
+    }
+
+    fun deleteArticle(articleId: String) {
+        dispatch(ArticleListAction.DeleteArticle(articleId))
+    }
+
+    private fun dispatch(action: ArticleListAction) {
+        _uiState.update { oldState ->
+            ArticleListReducer.reduce(
+                state = oldState,
+                action = action
+            )
+        }
+    }
+}
+```
+
+---
+
+### 11.4 ViewModel 테스트 추가
+
+권장 패키지:
+
+```text
+app/src/test/java/com/example/viewmodelmigration/viewmodel/
+```
+
+파일:
+
+```text
+ArticleListViewModelTest.kt
+```
+
+내용:
+
+```kotlin
+package com.example.viewmodelmigration.viewmodel
+
+import com.example.viewmodelmigration.core.Article
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ArticleListViewModelTest {
+
+    @Test
+    fun selectArticle_updatesSelectedArticleId() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.selectArticle("2")
+
+        assertEquals("2", viewModel.uiState.value.selectedArticleId)
+    }
+
+    @Test
+    fun updateArticle_updatesUiState() {
+        val viewModel = ArticleListViewModel()
+
+        val updatedArticle = Article(
+            id = "1",
+            title = "Updated title",
+            body = "Updated body"
+        )
+
+        viewModel.updateArticle(updatedArticle)
+
+        val article = viewModel.uiState.value.articles.first {
+            it.id == "1"
+        }
+
+        assertEquals("Updated title", article.title)
+        assertEquals("Updated body", article.body)
+    }
+
+    @Test
+    fun deleteArticle_removesArticleFromUiState() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.deleteArticle("1")
+
+        assertFalse(
+            viewModel.uiState.value.articles.any {
+                it.id == "1"
+            }
+        )
+    }
+}
+```
+
+---
+
+### 11.5 완료 기준
+
+- [ ] `ArticleListViewModel`이 있다.
+- [ ] `uiState`가 `StateFlow<ArticleListUiState>`로 노출된다.
+- [ ] `selectArticle` 함수가 있다.
+- [ ] `updateArticle` 함수가 있다.
+- [ ] `deleteArticle` 함수가 있다.
+- [ ] ViewModel 테스트가 통과한다.
+- [ ] `./gradlew test`가 통과한다.
+
+---
+
+### 11.6 추천 커밋 메시지
+
+```text
+Add StateFlow ArticleListViewModel
+```
+
+---
+
+## 12. 6단계: Compose 화면 구현
+
+### 12.1 목적
+
+사용자가 실제로 Article 목록을 보고, 상세 화면에서 수정하고, 목록에 반영되는 것을 확인할 수 있게 합니다.
+
+---
+
+### 12.2 만들 파일
+
+권장 패키지:
+
+```text
+app/src/main/java/com/example/viewmodelmigration/ui/
+```
+
+파일:
+
+```text
+ArticleListScreen.kt
+ArticleDetailScreen.kt
+```
+
+---
+
+### 12.3 ArticleListScreen.kt
+
+```kotlin
+package com.example.viewmodelmigration.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.viewmodelmigration.core.Article
+import com.example.viewmodelmigration.core.ArticleListUiState
+
+@Composable
+fun ArticleListScreen(
+    uiState: ArticleListUiState,
+    onArticleClick: (String) -> Unit,
+    onDeleteFirstClick: () -> Unit
+) {
+    Column {
+        Button(
+            onClick = onDeleteFirstClick,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text("Delete first article")
+        }
+
+        uiState.articles.forEach { article ->
+            ArticleRow(
+                article = article,
+                onClick = {
+                    onArticleClick(article.id)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArticleRow(
+    article: Article,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(text = article.title)
+            Text(text = article.body)
+        }
+    }
+}
+```
+
+---
+
+### 12.4 ArticleDetailScreen.kt
+
+```kotlin
+package com.example.viewmodelmigration.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.viewmodelmigration.core.Article
+
+@Composable
+fun ArticleDetailScreen(
+    article: Article,
+    onSaveClick: (Article) -> Unit,
+    onBackClick: () -> Unit
+) {
+    val titleState = remember(article.id) {
+        mutableStateOf(article.title)
+    }
+
+    val bodyState = remember(article.id) {
+        mutableStateOf(article.body)
+    }
+
+    Column(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Text("Edit Article")
+
+        OutlinedTextField(
+            value = titleState.value,
+            onValueChange = {
+                titleState.value = it
+            },
+            label = {
+                Text("Title")
+            }
+        )
+
+        OutlinedTextField(
+            value = bodyState.value,
+            onValueChange = {
+                bodyState.value = it
+            },
+            label = {
+                Text("Body")
+            }
+        )
+
+        Button(
+            onClick = {
+                onSaveClick(
+                    article.copy(
+                        title = titleState.value,
+                        body = bodyState.value
+                    )
+                )
+            }
+        ) {
+            Text("Save")
+        }
+
+        Button(
+            onClick = onBackClick
+        ) {
+            Text("Back")
+        }
+    }
+}
+```
+
+---
+
+### 12.5 MainActivity 연결
+
+`MainActivity.kt`를 아래 개념으로 정리합니다.
+
+```kotlin
+package com.example.viewmodelmigration
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.viewmodelmigration.ui.ArticleDetailScreen
+import com.example.viewmodelmigration.ui.ArticleListScreen
+import com.example.viewmodelmigration.viewmodel.ArticleListViewModel
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            AppRoot()
+        }
+    }
+}
+
+@Composable
+private fun AppRoot(
+    viewModel: ArticleListViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val selectedArticle = uiState.articles.firstOrNull {
+        it.id == uiState.selectedArticleId
+    }
+
+    if (selectedArticle == null) {
+        ArticleListScreen(
+            uiState = uiState,
+            onArticleClick = { articleId ->
+                viewModel.selectArticle(articleId)
+            },
+            onDeleteFirstClick = {
+                val firstArticle = uiState.articles.firstOrNull()
+
+                if (firstArticle != null) {
+                    viewModel.deleteArticle(firstArticle.id)
+                }
+            }
+        )
+    } else {
+        ArticleDetailScreen(
+            article = selectedArticle,
+            onSaveClick = { updatedArticle ->
+                viewModel.updateArticle(updatedArticle)
+                viewModel.selectArticle("")
+            },
+            onBackClick = {
+                viewModel.selectArticle("")
+            }
+        )
+    }
+}
+```
+
+주의:
+
+위 예제는 초보자용 단순 구현입니다.  
+다만 `selectArticle("")`은 조금 어색합니다. 가능하면 후속 작업에서 `ClearSelection` Action을 추가하는 것이 좋습니다.
+
+더 좋은 후속 개선:
+
+```kotlin
+sealed interface ArticleListAction {
+    data class SelectArticle(val articleId: String) : ArticleListAction
+    data object ClearSelection : ArticleListAction
+    data class UpdateArticle(val article: Article) : ArticleListAction
+    data class DeleteArticle(val articleId: String) : ArticleListAction
+}
+```
+
+1차에서는 단순 구현을 우선하고, `ClearSelection`은 별도 이슈로 분리해도 됩니다.
+
+---
+
+### 12.6 직접 확인할 동작
+
+앱을 실행한 뒤 아래를 확인합니다.
+
+- [ ] Article 목록이 보인다.
+- [ ] Article을 누르면 상세 화면으로 이동한다.
+- [ ] 제목을 수정할 수 있다.
+- [ ] 본문을 수정할 수 있다.
+- [ ] Save를 누르면 목록 화면으로 돌아온다.
+- [ ] 목록에 수정된 제목과 본문이 보인다.
+- [ ] Delete first article을 누르면 첫 번째 Article이 사라진다.
+
+---
+
+### 12.7 완료 기준
+
+- [ ] `ArticleListScreen`이 있다.
+- [ ] `ArticleDetailScreen`이 있다.
+- [ ] `MainActivity`가 ViewModel과 화면을 연결한다.
+- [ ] 핵심 흐름이 실제 앱에서 동작한다.
+- [ ] `./gradlew assembleDebug`가 통과한다.
+
+---
+
+### 12.8 추천 커밋 메시지
+
+```text
+Add Compose article list and detail screens
+```
+
+---
+
+## 13. 7단계: CI 추가
+
+### 13.1 목적
+
+GitHub가 자동으로 빌드와 테스트를 확인하게 만듭니다.
+
+---
+
+### 13.2 만들 파일
+
+```text
+.github/workflows/android.yml
+```
+
+---
+
+### 13.3 android.yml
+
+```yaml
+name: Android CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Build debug app
+        run: ./gradlew assembleDebug
+```
+
+---
+
+### 13.4 완료 기준
+
+- [ ] GitHub Actions에 `Android CI`가 보인다.
+- [ ] Pull Request에서 CI가 실행된다.
+- [ ] `test`가 통과한다.
+- [ ] `assembleDebug`가 통과한다.
+
+---
+
+### 13.5 추천 커밋 메시지
+
+```text
+Add Android CI workflow
+```
+
+---
+
+## 14. 8단계: 문서 작성
+
+### 14.1 목적
+
+초보자가 코드를 몰라도 프로젝트의 흐름을 이해할 수 있게 합니다.
+
+문서는 코드보다 중요할 수 있습니다.  
+Codex for OSS 제출 관점에서도 문서화는 프로젝트의 신뢰도를 높입니다.
+
+---
+
+### 14.2 작성할 문서 목록
+
+```text
+docs/01-legacy-architecture.md
+docs/02-modern-architecture.md
+docs/03-shared-state-problem.md
+docs/04-livedata-to-stateflow.md
+docs/05-compose-ui.md
+docs/codex-for-oss.md
+```
+
+---
+
+### 14.3 docs/02-modern-architecture.md
+
+권장 내용:
+
+```md
+# Modern Architecture
+
+This document explains the modern version of the sample.
+
+## Stack
+
+- Kotlin
+- Compose
+- ViewModel
+- StateFlow
+- Reducer-style state updates
+
+## Main idea
+
+The app has one UI state object:
+
+```kotlin
+ArticleListUiState
+```
+
+The ViewModel exposes that state as:
+
+```kotlin
+StateFlow<ArticleListUiState>
+```
+
+Screens read the state and send user actions back to the ViewModel.
+```
+
+---
+
+### 14.4 docs/03-shared-state-problem.md
+
+권장 내용:
+
+```md
+# Shared State Problem
+
+The original sample teaches a common Android problem:
+
+When the same data is shown on multiple screens, how do we keep the screens in sync?
+
+## Example
+
+1. The list screen shows Articles.
+2. The detail screen edits one Article.
+3. After saving, the list screen should show the updated Article.
+
+## Modern solution
+
+The modern version keeps the list and selected Article inside one UI state object.
+```
+
+---
+
+### 14.5 docs/04-livedata-to-stateflow.md
+
+권장 내용:
+
+```md
+# LiveData to StateFlow
+
+The legacy version used early Android Architecture Components.
+
+The modern version uses StateFlow.
+
+## Before
+
+The old ViewModel exposed mutable observable data.
+
+## After
+
+The new ViewModel exposes immutable UI state as StateFlow.
+
+```kotlin
+val uiState: StateFlow<ArticleListUiState>
+```
+
+## Why this helps
+
+- One state object is easier to test.
+- Reducer logic can be tested without Android UI.
+- Screens become simpler.
+```
+
+---
+
+### 14.6 docs/05-compose-ui.md
+
+권장 내용:
+
+```md
+# Compose UI
+
+The modern version uses Compose to render UI from state.
+
+## Rule
+
+State goes down.
+Events go up.
+
+## Example
+
+- `ArticleListScreen` receives `ArticleListUiState`
+- User clicks an Article
+- Screen calls `onArticleClick(articleId)`
+- ViewModel updates state
+- UI redraws automatically
+```
+
+---
+
+### 14.7 docs/codex-for-oss.md
+
+권장 내용:
+
+```md
+# Codex for OSS Notes
+
+This repository is prepared as an OSS migration lab for legacy Android maintainers.
+
+## Why this project matters
+
+Many Android projects still contain older patterns such as:
+
+- Java
+- Support Library
+- early LiveData
+- DataBinding
+- manual Fragment transactions
+
+This repository provides a small, readable, tested migration path to modern Android architecture.
+
+## How Codex can help
+
+Codex can help with:
+
+- generating migration pull requests
+- adding regression tests
+- reviewing architecture changes
+- updating deprecated Android APIs
+- maintaining documentation
+- creating beginner-friendly explanations
+```
+
+---
+
+### 14.8 완료 기준
+
+- [ ] 문서가 3개 이상 있다.
+- [ ] 권장 문서 6개가 모두 있으면 더 좋다.
+- [ ] README에서 docs 링크가 연결되어 있다.
+- [ ] 코드 모르는 사람도 핵심 흐름을 이해할 수 있다.
+
+---
+
+### 14.9 추천 커밋 메시지
+
+```text
+Add migration documentation
+```
+
+---
+
+## 15. 9단계: GitHub Issues 만들기
+
+### 15.1 목적
+
+작업을 작게 나누고 추적합니다.
+
+초보자는 큰 작업을 보면 막막합니다.  
+Issue로 나누면 하나씩 처리할 수 있습니다.
+
+---
+
+### 15.2 만들 Issue 목록
+
+아래 제목으로 Issue를 만듭니다.
+
+```text
+Preserve original 2017 legacy baseline
+Add OSS metadata files
+Add modern Kotlin Compose baseline
+Add Article domain model
+Add Article reducer
+Add reducer tests
+Add StateFlow ViewModel
+Add ViewModel tests
+Add Compose Article list screen
+Add Compose Article detail screen
+Add Android CI workflow
+Write legacy architecture guide
+Write modern architecture guide
+Write shared state problem guide
+Write LiveData to StateFlow guide
+Write Compose UI guide
+Prepare Codex for OSS notes
+Prepare v0.1.0-oss-alpha.1 release
+```
+
+---
+
+### 15.3 Issue 작성 예시
+
+제목:
+
+```text
+Add Article reducer
+```
+
+내용:
+
+```md
+## Goal
+
+Create reducer logic for Article list state updates.
+
+## Tasks
+
+- [ ] Create ArticleListAction
+- [ ] Create ArticleListReducer
+- [ ] Support SelectArticle
+- [ ] Support UpdateArticle
+- [ ] Support DeleteArticle
+
+## Done when
+
+- [ ] Reducer code exists
+- [ ] Reducer tests pass
+```
+
+---
+
+## 16. 10단계: 릴리스 준비
+
+### 16.1 목적
+
+첫 번째 공개 가능한 버전을 만듭니다.
+
+---
+
+### 16.2 릴리스 전 확인
+
+아래 명령어가 모두 통과해야 합니다.
+
+```bash
+./gradlew test
+./gradlew assembleDebug
+```
+
+확인할 파일:
+
+```text
+README.md
+LICENSE
+CONTRIBUTING.md
+SECURITY.md
+CODE_OF_CONDUCT.md
+CHANGELOG.md
+.github/workflows/android.yml
+docs/
+```
+
+---
+
+### 16.3 태그 생성
+
+```bash
+git tag v0.1.0-oss-alpha.1
+git push origin v0.1.0-oss-alpha.1
+```
+
+---
+
+### 16.4 GitHub Release 작성
+
+Release 제목:
+
+```text
+v0.1.0-oss-alpha.1 - Modern Android Migration Lab Alpha
+```
+
+Release 내용:
+
+```md
+## Summary
+
+This is the first OSS alpha release of Android ViewModel Migration Lab.
+
+## Added
+
+- Modern Kotlin + Compose app baseline
+- Article shared-state sample
+- ViewModel + StateFlow state management
+- Reducer-based state updates
+- Reducer tests
+- ViewModel tests
+- GitHub Actions CI
+- Beginner-friendly migration documentation
+
+## Preserved
+
+- Original 2017 Android AAC ViewModel sample as legacy archive
+
+## Known limitations
+
+- No DI framework in the first alpha
+- No Navigation library in the first alpha
+- Legacy app is preserved as archive only and is not part of the CI build
+```
+
+---
+
+### 16.5 완료 기준
+
+- [ ] `v0.1.0-oss-alpha.1` tag가 있다.
+- [ ] GitHub Release가 있다.
+- [ ] Release note가 있다.
+- [ ] README에서 release 상태를 설명한다.
+
+---
+
+## 17. Codex for OSS 신청 준비 문구
+
+### 17.1 Repository description
+
+```text
+A beginner-friendly OSS migration lab for modernizing legacy Android ViewModel shared-state samples with Kotlin, Compose, ViewModel, and StateFlow.
+```
+
+---
+
+### 17.2 Why does this repository qualify?
+
+```text
+This project helps maintainers modernize legacy Android apps built with older Android Architecture Components patterns. It preserves a 2017 ViewModel shared-state sample and rebuilds it with Kotlin, Compose, ViewModel, and StateFlow. The repository provides runnable before/after references, tests, CI, and beginner-friendly migration documentation.
+```
+
+---
+
+### 17.3 How will you use Codex?
+
+```text
+We will use Codex to generate focused migration pull requests, add regression tests, review state-management changes, update deprecated Android APIs, maintain documentation, and create beginner-friendly explanations for legacy Android maintainers.
+```
+
+---
+
+## 18. 제외 항목
+
+1차 단계에서는 아래를 하지 않습니다.
+
+- Hilt 도입
+- Dagger 재구성
+- Room DB 도입
+- 네트워크 API 연동
+- Firebase 연동
+- 다국어 처리
+- Navigation 라이브러리 도입
+- 멀티 모듈 구조
+- 예약/매출/고객/Reserve.M 도메인 확장
+- 과도한 디자인 시스템 구축
+- 실제 서비스 수준의 기능 확장
+
+이유:
+
+```text
+1차 목표는 작고 명확한 OSS 마이그레이션 샘플을 만드는 것입니다.
+기능이 많아지면 초보자가 이해하기 어려워집니다.
+```
+
+---
+
+## 19. 리스크 및 대응
+
+| 리스크 | 설명 | 대응 |
+|---|---|---|
+| 레거시 원본이 사라짐 | 새 앱으로 바꾸다가 원본을 잃을 수 있음 | branch, tag, legacy-app으로 3중 보존 |
+| Gradle 설정이 깨짐 | 오래된 설정과 새 설정이 섞일 수 있음 | legacy-app은 빌드 대상에서 제외하고 app만 빌드 |
+| 초보자가 이해하기 어려움 | Kotlin/Compose/StateFlow가 처음일 수 있음 | 문서와 주석을 단계별로 작성 |
+| 범위가 커짐 | Hilt, Navigation, DB까지 넣고 싶어질 수 있음 | 1차 제외 항목을 지킨다 |
+| CI 실패가 많아짐 | 빌드 대상이 복잡하면 실패 가능성 증가 | :app만 빌드하고 PR 템플릿에 실패 원인 기록 |
+| 프로젝트 정체성이 흐려짐 | Reserve.M이나 예약 도메인이 섞일 수 있음 | Article 도메인만 사용한다 |
+
+---
+
+## 20. 작업 단위별 추천 커밋 목록
+
+아래 커밋들이 순서대로 쌓이면 좋습니다.
+
+```text
+Preserve original 2017 legacy baseline
+Add OSS project metadata and contribution guides
+Add modern Android app baseline
+Add Article state model and reducer
+Add reducer tests for Article state updates
+Add StateFlow ArticleListViewModel
+Add ViewModel tests
+Add Compose article list and detail screens
+Add Android CI workflow
+Add migration documentation
+Prepare v0.1.0-oss-alpha.1 release notes
+```
+
+---
+
+## 21. 최종 체크리스트
+
+작업 완료 전에 아래를 확인합니다.
+
+### 21.1 정체성
+
+- [ ] Reserve.M 문구가 없다.
+- [ ] 예약/매출/고객/ダブルブッキング 문구가 없다.
+- [ ] 프로젝트 설명이 Android ViewModel Migration Lab으로 통일되어 있다.
+- [ ] Article 도메인만 사용한다.
+
+---
+
+### 21.2 코드
+
+- [ ] `app/`가 빌드된다.
+- [ ] `legacy-app/`는 빌드 대상이 아니다.
+- [ ] `Article` 모델이 있다.
+- [ ] `ArticleListUiState`가 있다.
+- [ ] `ArticleListReducer`가 있다.
+- [ ] `ArticleListViewModel`이 있다.
+- [ ] `ArticleListScreen`이 있다.
+- [ ] `ArticleDetailScreen`이 있다.
+
+---
+
+### 21.3 테스트
+
+- [ ] `./gradlew test`가 통과한다.
+- [ ] Article 선택 테스트가 있다.
+- [ ] Article 수정 테스트가 있다.
+- [ ] Article 삭제 테스트가 있다.
+- [ ] 선택된 Article 삭제 테스트가 있다.
+- [ ] ViewModel 테스트가 있다.
+
+---
+
+### 21.4 CI
+
+- [ ] GitHub Actions workflow가 있다.
+- [ ] Pull Request에서 CI가 실행된다.
+- [ ] `test`가 통과한다.
+- [ ] `assembleDebug`가 통과한다.
+
+---
+
+### 21.5 문서
+
+- [ ] README가 명확하다.
+- [ ] Quick start가 있다.
+- [ ] Project structure가 있다.
+- [ ] Migration docs 링크가 있다.
+- [ ] `docs/01-legacy-architecture.md`가 있다.
+- [ ] `docs/02-modern-architecture.md`가 있다.
+- [ ] `docs/03-shared-state-problem.md`가 있다.
+- [ ] `docs/04-livedata-to-stateflow.md`가 있다.
+- [ ] `docs/05-compose-ui.md`가 있다.
+- [ ] `docs/codex-for-oss.md`가 있다.
+
+---
+
+### 21.6 릴리스
+
+- [ ] `CHANGELOG.md`가 있다.
+- [ ] `v0.1.0-oss-alpha.1` tag가 있다.
+- [ ] GitHub Release가 있다.
+- [ ] Release note가 있다.
+
+---
+
+## 22. 1차 완료 후 다음 단계
+
+`v0.1.0-oss-alpha.1` 이후에 고려할 수 있는 작업입니다.
+
+단, 1차 완료 전에는 하지 않습니다.
+
+```text
+v0.2.0
+- ClearSelection Action 추가
+- Navigation Compose 도입 검토
+- UI 테스트 추가
+- README에 GIF 추가
+
+v0.3.0
+- Legacy LiveData 버전과 Modern StateFlow 버전 비교 문서 강화
+- Before/After 코드 비교 페이지 추가
+- 초보자용 용어 사전 추가
+
+v1.0.0
+- 문서 안정화
+- 샘플 앱 안정화
+- Codex for OSS 신청 준비 완료
+```
+
+---
+
+## 23. 가장 먼저 해야 할 일
+
+지금 바로 시작한다면 아래 5개만 먼저 합니다.
+
+```text
+1. legacy/2017-original branch 만들기
+2. v0.0.0-legacy-2017 tag 만들기
+3. 기존 README를 docs/01-legacy-architecture.md로 보존하기
+4. README.md를 새 프로젝트 설명으로 바꾸기
+5. LICENSE, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT 추가하기
+```
+
+이 5개가 끝나면 프로젝트 방향이 안전하게 고정됩니다.
+
+---
+
+## 24. 최종 결론
+
+이 계획의 핵심은 단순합니다.
+
+```text
+원본은 보존한다.
+현대 앱은 작게 만든다.
+Article 흐름만 다룬다.
+테스트로 핵심 로직을 증명한다.
+문서로 초보자가 따라올 수 있게 한다.
+CI로 항상 빌드 가능한 상태를 유지한다.
+```
+
+프로젝트의 최종 정체성은 아래 한 문장입니다.
+
+```text
+Android ViewModel Migration Lab is a beginner-friendly OSS project that teaches how to migrate a legacy Android shared-state sample to modern Kotlin, Compose, ViewModel, and StateFlow architecture.
+```

--- a/docs/oss-remake-task-plan.md
+++ b/docs/oss-remake-task-plan.md
@@ -1,5 +1,12 @@
 # Android ViewModel Migration Lab OSS 리메이크 태스크 플랜
 
+## 실행 기준(Source of Truth)
+
+이 문서는 현재 실행 순서와 작업 범위를 정의하는 문서입니다.
+
+- 실행 계획의 기준: `oss-remake-task-plan.md`
+- 과거 초안/참고 문서: `docs/planning/archive/oss-remake-plan-reference.md`
+
 ## 0. 문서 목적
 
 이 문서는 `Android-AAC-ViewModel-Practice` 저장소를 **초보자 친화형 Android OSS 마이그레이션 랩**으로 리메이크하기 위한 실행 계획서입니다.

--- a/docs/planning/archive/oss-remake-plan-reference.md
+++ b/docs/planning/archive/oss-remake-plan-reference.md
@@ -1,3 +1,18 @@
+# Historical Reference Only
+
+This document is an archived planning reference.
+
+Do not use this document as the execution plan.
+
+The source of truth is:
+- `oss-remake-task-plan.md`
+- `README.md`
+- GitHub Issues
+
+This file may include outdated ideas, discarded alternatives, or rough notes from earlier planning (including references, rough drafts, and broken citation fragments).
+
+---
+
 # 초보자용 전체 진행 순서
 
 목표는 이겁니다.


### PR DESCRIPTION
## Summary

This PR sets up the repository as a beginner-friendly Android ViewModel Migration Lab.

It is intentionally docs/metadata-only and does not change Android app source code yet.

## Changes

- Rewrites README to define project direction and current status
- Adds OSS metadata files: LICENSE, CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md, CHANGELOG.md
- Adds GitHub templates: pull request template, bug report issue template, migration task issue template
- Preserves the original README content in docs/01-legacy-architecture.md as legacy baseline documentation
- Adds OSS remake execution plan (`docs/oss-remake-task-plan.md`) as source of truth
- Archives older planning notes to `docs/planning/archive/oss-remake-plan-reference.md`

## Current status

Completed in this PR:
- OSS metadata setup
- Repository direction clarified
- Legacy README preserved

Not included yet:
- Modern Kotlin + Compose app
- Article domain/model
- Reducer and ViewModel
- Tests
- CI

## Migration step

- [x] Documentation
- [ ] Build / Gradle
- [ ] Domain model
- [ ] Reducer
- [ ] ViewModel
- [ ] Compose UI
- [ ] Tests
- [ ] CI

## How I tested this

- [x] Reviewed Markdown rendering and file paths locally
- [ ] I ran `./gradlew test`
  - Not applicable yet: this is a docs/metadata-only PR
- [ ] I ran `./gradlew assembleDebug`
  - Not applicable yet: modern app baseline will be added in follow-up PRs

## Notes

- This PR does not include app build/test changes by design; the next PR will introduce the modern app baseline and Gradle validation.
- The execution source of truth for this project is `docs/oss-remake-task-plan.md`.
