### PR TITLE
Add StateFlow ArticleListViewModel

### DIFF
--- a/app/src/main/java/com/example/viewmodelmigration/viewmodel/ArticleListViewModel.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/viewmodel/ArticleListViewModel.kt
@@ -1,0 +1,44 @@
+package com.example.viewmodelmigration.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.example.viewmodelmigration.core.Article
+import com.example.viewmodelmigration.core.ArticleListAction
+import com.example.viewmodelmigration.core.ArticleListReducer
+import com.example.viewmodelmigration.core.ArticleListUiState
+import com.example.viewmodelmigration.core.SampleArticles
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class ArticleListViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        ArticleListUiState(
+            articles = SampleArticles.create()
+        )
+    )
+
+    val uiState: StateFlow<ArticleListUiState> = _uiState.asStateFlow()
+
+    fun selectArticle(articleId: String) {
+        dispatch(ArticleListAction.SelectArticle(articleId))
+    }
+
+    fun updateArticle(article: Article) {
+        dispatch(ArticleListAction.UpdateArticle(article))
+    }
+
+    fun deleteArticle(articleId: String) {
+        dispatch(ArticleListAction.DeleteArticle(articleId))
+    }
+
+    private fun dispatch(action: ArticleListAction) {
+        _uiState.update { oldState ->
+            ArticleListReducer.reduce(
+                state = oldState,
+                action = action
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/example/viewmodelmigration/viewmodel/ArticleListViewModelTest.kt
+++ b/app/src/test/java/com/example/viewmodelmigration/viewmodel/ArticleListViewModelTest.kt
@@ -1,0 +1,51 @@
+package com.example.viewmodelmigration.viewmodel
+
+import com.example.viewmodelmigration.core.Article
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class ArticleListViewModelTest {
+
+    @Test
+    fun selectArticle_updatesSelectedArticleId() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.selectArticle("2")
+
+        assertEquals("2", viewModel.uiState.value.selectedArticleId)
+    }
+
+    @Test
+    fun updateArticle_updatesUiState() {
+        val viewModel = ArticleListViewModel()
+
+        val updatedArticle = Article(
+            id = "1",
+            title = "Updated title",
+            body = "Updated body"
+        )
+
+        viewModel.updateArticle(updatedArticle)
+
+        val article = viewModel.uiState.value.articles.first {
+            it.id == "1"
+        }
+
+        assertEquals("Updated title", article.title)
+        assertEquals("Updated body", article.body)
+    }
+
+    @Test
+    fun deleteArticle_removesArticleFromUiState() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.deleteArticle("1")
+
+        assertFalse(
+            viewModel.uiState.value.articles.any {
+                it.id == "1"
+            }
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ArticleListViewModel` using `StateFlow` for UI state.
- Initialize default state with `SampleArticles.create()`.
- Add action dispatch methods used by the UI layer:
  - `selectArticle(articleId: String)`
  - `updateArticle(article: Article)`
  - `deleteArticle(articleId: String)`
- Add reducer-based state transition tests for ViewModel behavior.

## Checklist
- [x] Add `ArticleListViewModel` in `app/src/main/java/com/example/viewmodelmigration/viewmodel/`
- [x] Expose `uiState: StateFlow<ArticleListUiState>`
- [x] Add `ArticleListViewModelTest`
- [x] Run `./gradlew test` ✅
- [x] Run `./gradlew assembleDebug` ✅

## Related Task Plan
- 11.5 완료 항목
  - `ArticleListViewModel` 추가
  - `uiState`는 `StateFlow<ArticleListUiState>` 노출
  - `selectArticle`, `updateArticle`, `deleteArticle` 함수 추가
  - ViewModel 테스트 추가

## Test environment
- `JAVA_HOME=/Applications/Android Studio.app/Contents/jbr/Contents/Home`
- `ANDROID_HOME=$HOME/Library/Android/sdk`
