### PR TITLE
Add Compose article list and detail screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")
     implementation("androidx.activity:activity-compose:1.9.0")
 
     implementation(platform("androidx.compose:compose-bom:2024.08.00"))

--- a/app/src/main/java/com/example/viewmodelmigration/MainActivity.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/MainActivity.kt
@@ -3,42 +3,91 @@ package com.example.viewmodelmigration
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.viewmodelmigration.ui.ArticleDetailScreen
+import com.example.viewmodelmigration.ui.ArticleListScreen
+import com.example.viewmodelmigration.viewmodel.ArticleListViewModel
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                MigrationLabWelcome()
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background
+            ) {
+                AppRoot()
             }
         }
     }
 }
 
 @Composable
-fun MigrationLabWelcome() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Text(text = "Android ViewModel Migration Lab")
-        Text(text = "Modern baseline is ready for next implementation PR.")
+private fun AppRoot(
+    viewModel: ArticleListViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    val selectedArticle = uiState.articles.firstOrNull {
+        it.id == uiState.selectedArticleId
+    }
+
+    if (selectedArticle == null) {
+        ArticleListScreen(
+            uiState = uiState,
+            onArticleClick = { articleId ->
+                viewModel.selectArticle(articleId)
+            },
+            onDeleteFirstClick = {
+                val firstArticle = uiState.articles.firstOrNull()
+                if (firstArticle != null) {
+                    viewModel.deleteArticle(firstArticle.id)
+                }
+            }
+        )
+    } else {
+        ArticleDetailScreen(
+            article = selectedArticle,
+            onSaveClick = { updatedArticle ->
+                viewModel.updateArticle(updatedArticle)
+                viewModel.clearSelection()
+            },
+            onBackClick = {
+                viewModel.clearSelection()
+            }
+        )
     }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun MigrationLabWelcomePreview() {
-    MigrationLabWelcome()
+private fun AppRootPreview() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Preview")
+        Button(
+            onClick = {}
+        ) {
+            Text("List")
+        }
+    }
 }

--- a/app/src/main/java/com/example/viewmodelmigration/ui/ArticleDetailScreen.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/ui/ArticleDetailScreen.kt
@@ -1,0 +1,82 @@
+package com.example.viewmodelmigration.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.viewmodelmigration.core.Article
+
+@Composable
+fun ArticleDetailScreen(
+    article: Article,
+    onSaveClick: (Article) -> Unit,
+    onBackClick: () -> Unit
+) {
+    var titleState by remember(article.id) {
+        mutableStateOf(article.title)
+    }
+
+    var bodyState by remember(article.id) {
+        mutableStateOf(article.body)
+    }
+
+    Column(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Text("Edit Article")
+
+        OutlinedTextField(
+            value = titleState,
+            onValueChange = {
+                titleState = it
+            },
+            label = {
+                Text("Title")
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        OutlinedTextField(
+            value = bodyState,
+            onValueChange = {
+                bodyState = it
+            },
+            label = {
+                Text("Body")
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Button(
+            onClick = {
+                onSaveClick(
+                    article.copy(
+                        title = titleState,
+                        body = bodyState
+                    )
+                )
+            }
+        ) {
+            Text("Save")
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = onBackClick
+        ) {
+            Text("Back")
+        }
+    }
+}

--- a/app/src/main/java/com/example/viewmodelmigration/ui/ArticleListScreen.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/ui/ArticleListScreen.kt
@@ -1,0 +1,59 @@
+package com.example.viewmodelmigration.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.viewmodelmigration.core.Article
+import com.example.viewmodelmigration.core.ArticleListUiState
+
+@Composable
+fun ArticleListScreen(
+    uiState: ArticleListUiState,
+    onArticleClick: (String) -> Unit,
+    onDeleteFirstClick: () -> Unit
+) {
+    Column {
+        Button(
+            onClick = onDeleteFirstClick,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text("Delete first article")
+        }
+
+        uiState.articles.forEach { article ->
+            ArticleRow(
+                article = article,
+                onClick = {
+                    onArticleClick(article.id)
+                }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ArticleRow(
+    article: Article,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Text(text = article.title)
+            Text(text = article.body)
+        }
+    }
+}

--- a/app/src/test/java/com/example/viewmodelmigration/core/ArticleListReducerTest.kt
+++ b/app/src/test/java/com/example/viewmodelmigration/core/ArticleListReducerTest.kt
@@ -88,4 +88,21 @@ class ArticleListReducerTest {
         assertEquals(null, newState.selectedArticleId)
         assertEquals(1, newState.articles.size)
     }
+
+    @Test
+    fun clearSelection_setsSelectedArticleIdNull() {
+        val oldState = ArticleListUiState(
+            articles = listOf(
+                Article(id = "1", title = "Keep", body = "Body 1")
+            ),
+            selectedArticleId = "1"
+        )
+
+        val newState = ArticleListReducer.reduce(
+            state = oldState,
+            action = ArticleListAction.ClearSelection
+        )
+
+        assertEquals(null, newState.selectedArticleId)
+    }
 }

--- a/app/src/test/java/com/example/viewmodelmigration/viewmodel/ArticleListViewModelTest.kt
+++ b/app/src/test/java/com/example/viewmodelmigration/viewmodel/ArticleListViewModelTest.kt
@@ -59,4 +59,14 @@ class ArticleListViewModelTest {
 
         assertNull(viewModel.uiState.value.selectedArticleId)
     }
+
+    @Test
+    fun clearSelection_clearsSelectedArticleId() {
+        val viewModel = ArticleListViewModel()
+
+        viewModel.selectArticle("1")
+        viewModel.clearSelection()
+
+        assertNull(viewModel.uiState.value.selectedArticleId)
+    }
 }


### PR DESCRIPTION
## Summary

Add the first Compose UI layer for the migration lab flow.

- Add `ArticleListScreen` for listing articles and selecting an item.
- Add `ArticleDetailScreen` for editing title/body.
- Connect `MainActivity` with `ArticleListViewModel` state + actions.
- Add `ClearSelection` usage on Save/Back to exit detail flow cleanly.
- Add compose ViewModel integration dependency.
- Add reducer/ViewModel tests for `ClearSelection`.

## Migration step

- [x] Compose UI
- [x] ViewModel

## How I tested this

- [x] `./gradlew test`
- [x] `./gradlew assembleDebug`

## Manual QA

- [ ] App launches successfully
- [ ] Article list is displayed
- [ ] Tapping an article opens detail screen
- [ ] Editing title/body works
- [ ] Save returns to list
- [ ] Updated article is reflected in list
- [ ] Back returns to list without saving

## Environment

- `JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home`
- `ANDROID_HOME=$HOME/Library/Android/sdk`
- OS: macOS (local)

## Notes

This is step 12 of `docs/oss-remake-task-plan.md`:
- `ArticleListScreen` is added
- `ArticleDetailScreen` is added
- `MainActivity` binds ViewModel to both screens
- The list/detail path is now runnable
- `clearSelection()` is covered by reducer + ViewModel tests.
