### PR TITLE
Add Android CI workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,29 @@
+name: Android CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Make Gradle executable
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests
+        run: ./gradlew test
+
+      - name: Build debug app
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
## Summary

Add Android CI workflow so pull requests and main branch pushes run validation automatically.

- Add `.github/workflows/android.yml`
- Run `./gradlew test` on every PR and push to main
- Run `./gradlew assembleDebug` on every PR and push to main
- Use `actions/setup-java` with Temurin 17

## Migration step

- [x] CI

## How I tested this

- [x] `./gradlew test`
- [x] `./gradlew assembleDebug`

## Environment

- `JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home`
- `ANDROID_HOME=$HOME/Library/Android/sdk`
- OS: macOS (local)

## Notes

This follows Step 13 (CI 추가) in `docs/oss-remake-task-plan.md`.
