### PR TITLE
Prepare v0.1.0 OSS alpha release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,32 @@
 # Changelog
 
-## Unreleased
+## v0.1.0-oss-alpha.1 - Modern Android Migration Lab Alpha
 
 ### Added
+
 - Rewrote README for OSS migration lab direction and status
 - Added OSS metadata files
 - Added GitHub pull request and issue templates
 - Preserved original README in docs as legacy architecture archive
+- Added modern Kotlin + Compose app baseline
+- Added Article shared-state model and reducer foundation
+- Added ViewModel + StateFlow state management
+- Added reducer tests
+- Added ViewModel tests
+- Added Compose article list/detail screens
+- Added Android CI workflow
+- Added migration documentation set for modern architecture and state flow
+
+### Preserved
+
+- Original 2017 Android AAC ViewModel sample preserved in `legacy-app/`
+
+### Known limitations
+
+- First alpha intentionally excludes DI frameworks (Hilt/Dagger), Navigation library, and database/cloud integrations.
+- Legacy app is archived only and excluded from CI build scope.
+
+## Unreleased
+
+### Added
+- Release note preparation for v0.1.0-oss-alpha.1

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Not yet implemented:
 - OSS release preparation:
   - `v0.1.0-oss-alpha.1` 릴리스 메모
   - CHANGELOG 정리 및 공개 릴리스 노트
-- OSS release documentation workflow
+  - `v0.1.0-oss-alpha.1` 태그 생성
+  - GitHub Release 게시
 
 ## What this project will teach
 
@@ -81,7 +82,7 @@ The future modern version will provide:
 - [x] Add unit tests
 - [x] Add Android CI workflow
 - [x] Publish migration document bundle
-- [ ] Add release metadata for v0.1.0-oss-alpha.1
+- [x] Add release notes and changelog section for v0.1.0-oss-alpha.1
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The future modern version will provide:
 - [Shared State Problem](docs/03-shared-state-problem.md)
 - [LiveData to StateFlow](docs/04-livedata-to-stateflow.md)
 - [Compose UI Guide](docs/05-compose-ui.md)
+- [Release Notes: v0.1.0-oss-alpha.1](docs/release-notes-v0.1.0-oss-alpha.1.md)
 - [Migration Task Plan (source of truth)](docs/oss-remake-task-plan.md)
 - [Codex for OSS](docs/codex-for-oss.md)
 - [Historical planning references](docs/planning/archive/oss-remake-plan-reference.md)

--- a/docs/release-notes-v0.1.0-oss-alpha.1.md
+++ b/docs/release-notes-v0.1.0-oss-alpha.1.md
@@ -1,0 +1,41 @@
+# v0.1.0-oss-alpha.1 - Android ViewModel Migration Lab Alpha
+
+This is the first OSS alpha release of Android ViewModel Migration Lab.
+
+## Summary
+
+- Rebuild plan completed for the 1st alpha milestone:
+  - Modern Kotlin + Compose baseline
+  - Article shared-state model and reducer
+  - StateFlow-based ViewModel
+  - Reducer and ViewModel unit tests
+  - Android CI workflow (`./gradlew test`, `./gradlew assembleDebug`)
+  - Beginner-focused migration documentation set
+
+## Added
+
+- Modern Kotlin + Compose app baseline
+- Article shared-state sample
+- ViewModel + StateFlow state management
+- Reducer-based state updates
+- Reducer tests
+- ViewModel tests
+- GitHub Actions CI
+- Migration documentation:
+  - `docs/02-modern-architecture.md`
+  - `docs/03-shared-state-problem.md`
+  - `docs/04-livedata-to-stateflow.md`
+  - `docs/05-compose-ui.md`
+  - `docs/codex-for-oss.md`
+
+## Preserved
+
+- Legacy 2017 Android AAC ViewModel sample preserved as archive in `legacy-app/`
+- Migration history and baseline notes documented in `docs/01-legacy-architecture.md`
+
+## Known limitations
+
+- No DI framework in first alpha (ex: Hilt/Dagger)
+- No Navigation library in first alpha
+- Legacy archive is preserved for reference and not part of CI build
+


### PR DESCRIPTION
## Summary

This PR prepares the first alpha release documentation set.

## Changes

- Added `CHANGELOG.md` release section for `v0.1.0-oss-alpha.1`.
- Added draft release notes document: `docs/release-notes-v0.1.0-oss-alpha.1.md`.
- Updated `README.md` release readiness status for pending tag and GitHub Release.

## Scope

Documentation and release-note prep only.

## Verification

- [x] Files added/updated for release documentation
- [ ] Docs-only PR: build verification intentionally not required

This aligns with the roadmap after `Prepare v0.1.0-oss-alpha.1` docs milestone.
