### PR TITLE
Add release checklist for v0.1.0 alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The future modern version will provide:
 - [LiveData to StateFlow](docs/04-livedata-to-stateflow.md)
 - [Compose UI Guide](docs/05-compose-ui.md)
 - [Release Notes: v0.1.0-oss-alpha.1](docs/release-notes-v0.1.0-oss-alpha.1.md)
+- [Release Guide: v0.1.0-oss-alpha.1](docs/release-guide-v0.1.0-oss-alpha.1.md)
 - [Migration Task Plan (source of truth)](docs/oss-remake-task-plan.md)
 - [Codex for OSS](docs/codex-for-oss.md)
 - [Historical planning references](docs/planning/archive/oss-remake-plan-reference.md)

--- a/docs/release-guide-v0.1.0-oss-alpha.1.md
+++ b/docs/release-guide-v0.1.0-oss-alpha.1.md
@@ -1,0 +1,44 @@
+# Release Guide: v0.1.0-oss-alpha.1
+
+이 문서는 Android ViewModel Migration Lab의 첫 공개 릴리스를 위한 체크리스트입니다.
+
+## 1) Prerequisites
+
+- PR #9(`Prepare v0.1.0 OSS alpha release notes`)가 main에 머지되어야 함
+- `README.md`, `CHANGELOG.md`에 릴리스 항목이 반영되어 있어야 함
+- CI(`./gradlew test`, `./gradlew assembleDebug`)가 통과해야 함
+
+## 2) Release tag
+
+```bash
+git fetch --all --prune
+git checkout main
+git pull
+git tag v0.1.0-oss-alpha.1
+git push origin v0.1.0-oss-alpha.1
+```
+
+## 3) GitHub Release
+
+### 제목
+
+`v0.1.0-oss-alpha.1 - Modern Android Migration Lab Alpha`
+
+### 본문
+
+`docs/release-notes-v0.1.0-oss-alpha.1.md`를 복사해서 붙여넣기
+
+### CLI 예시
+
+```bash
+gh release create v0.1.0-oss-alpha.1 \
+  --title "v0.1.0-oss-alpha.1 - Modern Android Migration Lab Alpha" \
+  --notes-file docs/release-notes-v0.1.0-oss-alpha.1.md
+```
+
+## 4) 릴리스 제한 범위(1차 Alpha)
+
+- DI(Hilt/Dagger) 미적용
+- Navigation 라이브러리 미적용
+- DB/클라우드 연동 미적용
+- `legacy-app/`는 아카이브용으로 보존


### PR DESCRIPTION
## Summary

Add a release checklist guide for v0.1.0-oss-alpha.1 to keep the final release steps repeatable and explicit.

## Changes

- Added `docs/release-guide-v0.1.0-oss-alpha.1.md`
  - verification checklist
  - tag creation commands
  - GitHub Release command example
  - release limitation summary
- Added README link to the release guide

## Scope

Release documentation only.

## Notes

No application source code changes in this PR.
