### PR TITLE
Add v0.1.0 alpha release helper script

### DIFF
--- a/docs/release-guide-v0.1.0-oss-alpha.1.md
+++ b/docs/release-guide-v0.1.0-oss-alpha.1.md
@@ -5,6 +5,7 @@
 ## 1) Prerequisites
 
 - PR #9(`Prepare v0.1.0 OSS alpha release notes`)가 main에 머지되어야 함
+- PR #11(`Add tag-triggered release workflow for v0.1.0 alpha`)가 main에 머지되어야 함
 - `README.md`, `CHANGELOG.md`에 릴리스 항목이 반영되어 있어야 함
 - CI(`./gradlew test`, `./gradlew assembleDebug`)가 통과해야 함
 
@@ -36,7 +37,20 @@ gh release create v0.1.0-oss-alpha.1 \
   --notes-file docs/release-notes-v0.1.0-oss-alpha.1.md
 ```
 
-## 4) 릴리스 제한 범위(1차 Alpha)
+## 4) 원클릭 릴리스 스크립트(선택)
+
+```bash
+./scripts/release-v0.1.0-oss-alpha.1.sh
+```
+
+이 스크립트는 다음을 차례로 수행합니다.
+
+- `docs/release-notes-v0.1.0-oss-alpha.1.md` 존재 확인
+- `./gradlew test`, `./gradlew assembleDebug` 실행
+- `v0.1.0-oss-alpha.1` 태그 생성/푸시
+- GitHub Release 생성
+
+## 5) 릴리스 제한 범위(1차 Alpha)
 
 - DI(Hilt/Dagger) 미적용
 - Navigation 라이브러리 미적용

--- a/scripts/release-v0.1.0-oss-alpha.1.sh
+++ b/scripts/release-v0.1.0-oss-alpha.1.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG="v0.1.0-oss-alpha.1"
+RELEASE_NOTES="docs/release-notes-${TAG}.md"
+RELEASE_NAME="${TAG} - Android ViewModel Migration Lab Alpha"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required: https://cli.github.com/"
+  exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required"
+  exit 1
+fi
+
+if [ ! -f "$RELEASE_NOTES" ]; then
+  echo "Missing release notes: $RELEASE_NOTES"
+  exit 1
+fi
+
+git fetch --all --prune
+git checkout main
+git pull origin main
+
+./gradlew test
+./gradlew assembleDebug
+
+if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
+  echo "Tag $TAG already exists locally."
+  exit 0
+fi
+
+git tag "$TAG"
+git push origin "$TAG"
+
+gh release create "$TAG" \
+  --title "$RELEASE_NAME" \
+  --notes-file "$RELEASE_NOTES"

--- a/scripts/release-v0.1.0-oss-alpha.1.sh
+++ b/scripts/release-v0.1.0-oss-alpha.1.sh
@@ -5,6 +5,12 @@ TAG="v0.1.0-oss-alpha.1"
 RELEASE_NOTES="docs/release-notes-${TAG}.md"
 RELEASE_NAME="${TAG} - Android ViewModel Migration Lab Alpha"
 
+create_release() {
+  gh release create "$TAG" \
+    --title "$RELEASE_NAME" \
+    --notes-file "$RELEASE_NOTES"
+}
+
 if ! command -v gh >/dev/null 2>&1; then
   echo "gh CLI is required: https://cli.github.com/"
   exit 1
@@ -29,12 +35,16 @@ git pull origin main
 
 if git rev-parse --verify "$TAG" >/dev/null 2>&1; then
   echo "Tag $TAG already exists locally."
+  if gh release view "$TAG" >/dev/null 2>&1; then
+    echo "Release $TAG already exists."
+    exit 0
+  fi
+  echo "Tag exists but release is missing. Creating release for existing tag."
+  create_release
   exit 0
 fi
 
 git tag "$TAG"
 git push origin "$TAG"
 
-gh release create "$TAG" \
-  --title "$RELEASE_NAME" \
-  --notes-file "$RELEASE_NOTES"
+create_release


### PR DESCRIPTION
## Summary

This PR adds a one-command local helper for the first alpha release.

### Changes

- Added `scripts/release-v0.1.0-oss-alpha.1.sh`
- The script validates release notes, runs `./gradlew test`, `./gradlew assembleDebug`, creates/pushes the release tag, and creates GitHub Release
- Updated `docs/release-guide-v0.1.0-oss-alpha.1.md` with:
  - PR #11 prerequisite note
  - one-command release execution section

### Scope

Release execution helper only.

### Verification

- Script is executable (`chmod +x`)
- The script checks for required command/tools and release notes before tag/release
- PR remains compatible with the tag-triggered GitHub Actions release workflow
