### PR TITLE
Update release status after v0.1.0-oss-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,14 @@
 - Added Android CI workflow
 - Added migration documentation set for modern architecture and state flow
 - Added release workflow for tag-triggered `v0.1.0-oss-alpha.1` publish
+- Added release notes and published `v0.1.0-oss-alpha.1` GitHub release
 
 ### Preserved
 
 - Original 2017 Android AAC ViewModel sample preserved in `legacy-app/`
+- `v0.1.0-oss-alpha.1` tag and GitHub Release published
 
 ### Known limitations
 
 - First alpha intentionally excludes DI frameworks (Hilt/Dagger), Navigation library, and database/cloud integrations.
 - Legacy app is archived only and excluded from CI build scope.
-
-## Unreleased
-
-### Added
-- `v0.1.0-oss-alpha.1` tag와 GitHub Release 발행은 아직 대기 중입니다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.1.0-oss-alpha.1 - Modern Android Migration Lab Alpha
+## v0.1.0-oss-alpha.1 - 2026-06-07
 
 ### Added
 
@@ -17,12 +17,12 @@
 - Added Android CI workflow
 - Added migration documentation set for modern architecture and state flow
 - Added release workflow for tag-triggered `v0.1.0-oss-alpha.1` publish
-- Added release notes and published `v0.1.0-oss-alpha.1` GitHub release
+- Added release notes and published `v0.1.0-oss-alpha.1` GitHub release (sample debug APK asset)
 
 ### Preserved
 
 - Original 2017 Android AAC ViewModel sample preserved in `legacy-app/`
-- `v0.1.0-oss-alpha.1` tag and GitHub Release published
+- `v0.1.0-oss-alpha.1` tag and GitHub Release published as first OSS alpha milestone
 
 ### Known limitations
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,7 @@ Completed in this phase:
 - Compose list/detail screens implemented
 - Android CI workflow added
 - Release workflow added for `v0.1.0-oss-alpha.1` tag push
-
-Not yet implemented:
-
-- OSS release preparation:
-  - `v0.1.0-oss-alpha.1` 태그 생성
-  - GitHub Release 게시
+- `v0.1.0-oss-alpha.1` tag and GitHub Release published
 
 ## What this project will teach
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Completed in this phase:
 - Compose list/detail screens implemented
 - Android CI workflow added
 - Release workflow added for `v0.1.0-oss-alpha.1` tag push
-- `v0.1.0-oss-alpha.1` tag and GitHub Release published
+- `v0.1.0-oss-alpha.1` first OSS alpha release is published
+  - GitHub Release: `v0.1.0-oss-alpha.1`
+  - Sample debug APK: `app-debug.apk`
 
 ## What this project will teach
 


### PR DESCRIPTION
## Summary

- Polished release status docs to align exactly with the alpha release outcome.
- `README.md`
  - Removed pending release preparation language.
  - Added explicit `first OSS alpha release` wording.
  - Added `app-debug.apk` as a sample/debug APK.
- `CHANGELOG.md`
  - Added release date to the `v0.1.0-oss-alpha.1` heading.
  - Clarified that this is the first OSS alpha milestone.

## Verification

- GitHub Release created: https://github.com/leesunghyun/Android-AAC-ViewModel-Practice/releases/tag/v0.1.0-oss-alpha.1
- Release workflow run: https://github.com/leesunghyun/Android-AAC-ViewModel-Practice/actions/runs/27081113014
- Asset: `app-debug.apk` uploaded to the release

## Scope

Docs-only status sync following v0.1.0 alpha release milestone.
