### PR TITLE
Add collectAsStateWithLifecycle for app UI state

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Only `app/` is built in the first alpha.
 ## Next milestones (planned, v0.2)
 
 - [ ] Add UI tests for article edit/delete interactions
-- [ ] Add `collectAsStateWithLifecycle` in Compose state collection
+- [x] Add `collectAsStateWithLifecycle` in Compose state collection
 - [ ] Replace demo placeholder with real screen recording (`docs/images/demo.gif`)
 - [ ] Improve Article detail validation UX
 - [ ] Prepare v0.2.0 roadmap and release notes

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 dependencies {
     implementation("androidx.core:core-ktx:1.13.1")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.3")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.3")
     implementation("androidx.activity:activity-compose:1.9.0")
 

--- a/app/src/main/java/com/example/viewmodelmigration/MainActivity.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/MainActivity.kt
@@ -12,12 +12,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.viewmodelmigration.ui.ArticleDetailScreen
 import com.example.viewmodelmigration.ui.ArticleListScreen
@@ -41,7 +41,7 @@ class MainActivity : ComponentActivity() {
 private fun AppRoot(
     viewModel: ArticleListViewModel = viewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val selectedArticle = uiState.articles.firstOrNull {
         it.id == uiState.selectedArticleId


### PR DESCRIPTION
## Summary

Improves Compose UI state collection to be lifecycle-aware in the v0.2 milestone.

## What changed

- Added `androidx.lifecycle:lifecycle-runtime-compose` dependency to modern app module.
- Replaced `collectAsState()` with `collectAsStateWithLifecycle()` in `MainActivity`.
- Updated README roadmap to mark this milestone item as completed.

## Scope

- Lifecycle-aware UI state collection in the app layer.

## Notes

This is intentionally minimal and docs-safe: no behavior changes in ViewModel/reducer logic.

