### PR TITLE
Align README and compose docs with current state collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A beginner-friendly OSS migration lab that modernizes a 2017 Android AAC ViewModel shared-state sample with Kotlin, Compose, ViewModel, and StateFlow.
 
-This repository is now in the **release readiness phase** of the OSS rebuild.
+This repository has completed its first OSS alpha release and is now preparing v0.2 improvements.
 
 ## Requirements
 
@@ -43,7 +43,7 @@ The original project shared an `Article` model between screens:
 - Detail screen edits a selected Article
 - Save should update the list state immediately
 
-## Planned modern solution
+## Current modern solution
 
 The modern version provides:
 - Kotlin + Compose UI
@@ -141,10 +141,13 @@ Only `app/` is built in the first alpha.
 ## Next milestones (planned, v0.2)
 
 - [ ] Add UI tests for article edit/delete interactions
-- [x] Add `collectAsStateWithLifecycle` in Compose state collection
 - [ ] Replace demo placeholder with real screen recording (`docs/images/demo.gif`)
 - [ ] Improve Article detail validation UX
 - [ ] Prepare v0.2.0 roadmap and release notes
+
+## Recently completed after v0.1.0
+
+- [x] Add `collectAsStateWithLifecycle` in Compose state collection
 
 ## Contributing
 

--- a/docs/05-compose-ui.md
+++ b/docs/05-compose-ui.md
@@ -49,7 +49,7 @@
 
 ## 3) 상태 연동 포인트
 
-- `collectAsState()`로 `uiState`를 구독
+- `collectAsStateWithLifecycle()`로 `uiState`를 lifecycle-aware하게 구독
 - 상세에서 저장 시:
   1. `onSaveClick(updatedArticle)`
   2. `ViewModel`에서 reducer로 `UpdateArticle` 실행
@@ -69,4 +69,3 @@
 
 - 이 단계는 교육/샘플 목적이므로 UI/UX는 최소 기능 위주
 - 현재 삭제 동작은 “첫 번째 항목 삭제” 데모로 두었으므로, 실제 요구사항 반영 시에는 선택 삭제 액션으로 바꿔야 함
-


### PR DESCRIPTION
## Summary

Small documentation cleanup to keep v0.2 planning and implementation state consistent with current code.

### What changed

- Updated README copy to reflect post-alpha / v0.2 planning status.
- Renamed `Planned modern solution` to `Current modern solution`.
- Moved the completed `collectAsStateWithLifecycle` item out of the planned v0.2 milestones into a dedicated completed-after section.
- Updated `docs/05-compose-ui.md` to describe the actual lifecycle-aware state collection used in `MainActivity`.

### Scope

Docs-only changes for onboarding and documentation consistency.

### Checks

- No code or CI changes were made in this PR.
- README and docs now match current implementation.
