### PR TITLE
Add Compose UI smoke tests for article flow

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
 
     testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("androidx.test.ext:junit:1.2.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.0")
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/app/src/androidTest/java/com/example/viewmodelmigration/ArticleUiSmokeTest.kt
+++ b/app/src/androidTest/java/com/example/viewmodelmigration/ArticleUiSmokeTest.kt
@@ -1,0 +1,41 @@
+package com.example.viewmodelmigration
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+
+class ArticleUiSmokeTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun editArticle_updatesListImmediatelyAfterSave() {
+        composeTestRule.onNodeWithTag("article-row-1").performClick()
+
+        composeTestRule.onNodeWithTag("detail-title-field").performTextClearance()
+        composeTestRule.onNodeWithTag("detail-title-field").performTextInput("Legacy ViewModel (Updated)")
+        composeTestRule.onNodeWithTag("detail-body-field").performTextClearance()
+        composeTestRule.onNodeWithTag("detail-body-field").performTextInput("Updated for smoke test")
+
+        composeTestRule.onNodeWithTag("detail-save-button").performClick()
+
+        composeTestRule.onNodeWithText("Legacy ViewModel (Updated)").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("article-row-1").performClick()
+        composeTestRule.onNodeWithTag("detail-title-field").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("detail-body-field").assertIsDisplayed()
+    }
+
+    @Test
+    fun deleteFirstArticle_removesFirstRowFromList() {
+        composeTestRule.onNodeWithTag("delete-first-article-button").performClick()
+        composeTestRule.onNodeWithTag("article-row-1").assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/example/viewmodelmigration/ui/ArticleDetailScreen.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/ui/ArticleDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.example.viewmodelmigration.core.Article
 
@@ -38,27 +39,32 @@ fun ArticleDetailScreen(
 
         OutlinedTextField(
             value = titleState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("detail-title-field"),
             onValueChange = {
                 titleState = it
             },
             label = {
                 Text("Title")
-            },
-            modifier = Modifier.fillMaxWidth()
+            }
         )
 
         OutlinedTextField(
             value = bodyState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("detail-body-field"),
             onValueChange = {
                 bodyState = it
             },
             label = {
                 Text("Body")
-            },
-            modifier = Modifier.fillMaxWidth()
+            }
         )
 
         Button(
+            modifier = Modifier.testTag("detail-save-button"),
             onClick = {
                 onSaveClick(
                     article.copy(
@@ -74,6 +80,7 @@ fun ArticleDetailScreen(
         Spacer(modifier = Modifier.height(8.dp))
 
         Button(
+            modifier = Modifier.testTag("detail-back-button"),
             onClick = onBackClick
         ) {
             Text("Back")

--- a/app/src/main/java/com/example/viewmodelmigration/ui/ArticleListScreen.kt
+++ b/app/src/main/java/com/example/viewmodelmigration/ui/ArticleListScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.example.viewmodelmigration.core.Article
 import com.example.viewmodelmigration.core.ArticleListUiState
@@ -22,7 +23,9 @@ fun ArticleListScreen(
     Column {
         Button(
             onClick = onDeleteFirstClick,
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier
+                .padding(16.dp)
+                .testTag("delete-first-article-button")
         ) {
             Text("Delete first article")
         }
@@ -47,6 +50,7 @@ private fun ArticleRow(
         modifier = Modifier
             .fillMaxWidth()
             .padding(8.dp)
+            .testTag("article-row-${article.id}")
             .clickable(onClick = onClick)
     ) {
         Column(


### PR DESCRIPTION
## Summary

Adds first Compose UI smoke tests for the critical article flow and adds stable `testTag`s for deterministic UI testing.

### What changed

- Added `androidx.compose.ui:ui-test-junit4` to `androidTest` dependencies.
- Added `testTag` markers to list/detail screens for deterministic node selection.
- Added `ArticleUiSmokeTest` with scenarios:
  - Edit first article title/body and save, then verify updated title appears in list.
  - Delete first article and verify its row is removed.

### Scope

- Test support + small UI instrumentation for v0.2 readiness.

### Notes

This is a smoke-level coverage baseline for key migration flow:
`List → Detail → Edit → Save → List` and delete interaction.

Current CI in this repo only runs:
- `./gradlew test`
- `./gradlew assembleDebug`

So instrumented UI tests are not executed in the default pipeline yet.
