### PR TITLE
Generalize release workflow for v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ env:
 on:
   push:
     tags:
-      - "v0.1.0-oss-alpha.1"
+      - "v*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Generalizes the release workflow trigger so v0.2 (and later) version tags can use the same release automation path.

### What changed

- Updated `.github/workflows/release.yml`:
  - `on.push.tags` changed from a single alpha tag to `v*`.

### Scope

- Release automation extensibility for future tagged releases.

### Notes

Release note validation remains dynamic and requires `docs/release-notes-${{ github.ref_name }}.md` for each tagged release.
