### PR TITLE
Prepare v0.2.0-oss-alpha.1 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Added article detail validation UX (required title/body checks + inline feedback + disabled save when invalid).
+- Added reducer invalid-id guard test coverage.
+- Expanded compose UI smoke tests for validation and back-without-save behavior.
+- Prepared v0.2 release assets: `docs/release-guide-v0.2.0-oss-alpha.1.md`, `docs/release-notes-v0.2.0-oss-alpha.1.md`.
+
+### Known limitations
+
+- v0.2 release is prepared but tag/release has not been published yet.
+
 ## v0.1.0-oss-alpha.1 - 2026-06-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Manual smoke check:
 ## Release status
 
 - First OSS alpha release: [v0.1.0-oss-alpha.1](https://github.com/leesunghyun/android-viewmodel-migration-lab/releases/tag/v0.1.0-oss-alpha.1)
+- v0.2 alpha preparation: `v0.2.0-oss-alpha.1` notes/guide are prepared
+  - [Release Notes: v0.2.0-oss-alpha.1](docs/release-notes-v0.2.0-oss-alpha.1.md)
+  - [Release Guide: v0.2.0-oss-alpha.1](docs/release-guide-v0.2.0-oss-alpha.1.md)
 - APK is provided as a sample debug artifact for manual smoke testing (not production release).
 
 For full release details and run verification commands, see:
@@ -168,8 +171,9 @@ Only `app/` is built in the first alpha.
 - [Compose UI Guide](docs/05-compose-ui.md)
 - [Release Notes: v0.1.0-oss-alpha.1](docs/release-notes-v0.1.0-oss-alpha.1.md)
 - [Release Guide: v0.1.0-oss-alpha.1](docs/release-guide-v0.1.0-oss-alpha.1.md)
-- [Roadmap: v0.2.0](docs/roadmap-v0.2.0.md)
 - [Release Notes: v0.2.0-oss-alpha.1](docs/release-notes-v0.2.0-oss-alpha.1.md)
+- [Release Guide: v0.2.0-oss-alpha.1](docs/release-guide-v0.2.0-oss-alpha.1.md)
+- [Roadmap: v0.2.0](docs/roadmap-v0.2.0.md)
 - [Migration Task Plan (source of truth)](docs/oss-remake-task-plan.md)
 - [Codex for OSS](docs/codex-for-oss.md)
 

--- a/docs/release-guide-v0.2.0-oss-alpha.1.md
+++ b/docs/release-guide-v0.2.0-oss-alpha.1.md
@@ -1,0 +1,53 @@
+# Release Guide: v0.2.0-oss-alpha.1
+
+이 문서는 Android ViewModel Migration Lab의 v0.2.0-oss-alpha.1 릴리스를 위한 체크리스트입니다.
+
+## 1) Prerequisites
+
+- PR #22(`Improve article validation and test coverage`)가 `main`에 머지되어야 함
+- `README.md`, `CHANGELOG.md` 및 v0.2 릴리스 문서가 반영되어 있어야 함
+- CI (`./gradlew test`, `./gradlew assembleDebug`)가 통과해야 함
+
+## 2) Release tag
+
+```bash
+git fetch --all --prune
+git checkout main
+git pull origin main
+git tag v0.2.0-oss-alpha.1
+git push origin v0.2.0-oss-alpha.1
+```
+
+## 3) GitHub Release
+
+### 제목
+
+`v0.2.0-oss-alpha.1 - Android ViewModel Migration Lab Alpha`
+
+### 본문
+
+`docs/release-notes-v0.2.0-oss-alpha.1.md`을 사용
+
+### CLI 예시
+
+```bash
+gh release create v0.2.0-oss-alpha.1 \
+  --title "v0.2.0-oss-alpha.1 - Android ViewModel Migration Lab Alpha" \
+  --notes-file docs/release-notes-v0.2.0-oss-alpha.1.md
+```
+
+## 4) GitHub Actions 자동 릴리스(권장)
+
+`main`에서 `v0.2.0-oss-alpha.1` 태그를 push하면 `.github/workflows/release.yml`에서 릴리스가 자동 실행됩니다.
+
+- `./gradlew test` 재실행
+- `./gradlew assembleDebug` 재실행
+- `docs/release-notes-v0.2.0-oss-alpha.1.md` 존재 검증
+- `app-debug.apk` 업로드
+
+## 5) 릴리스 범위(확인용)
+
+- 저장 유효성 검사: 제목/본문 필수 입력 및 실시간 검증 반영
+- 테스트: 잘못된 선택값 방어 + Back-without-save 플로우 커버
+- UI/동영상: 데모 GIF가 실제 앱 흐름으로 교체됨
+- 문서: v0.2 체크리스트 및 릴리스 링크 정합성 정리

--- a/docs/release-notes-v0.2.0-oss-alpha.1.md
+++ b/docs/release-notes-v0.2.0-oss-alpha.1.md
@@ -1,26 +1,47 @@
 # v0.2.0-oss-alpha.1 - Android ViewModel Migration Lab Alpha
 
-This release notes file is prepared in advance for the v0.2 iteration.
+이 릴리스는 v0.2.0-oss-alpha.1 준비 기준으로 반영한 변경 사항을 정리한 노트입니다.
 
 ## Summary
 
-- Improve migration documentation completeness
-- Replace README demo placeholder with a real recording (`docs/images/demo.gif`)
-- Expand Compose UI coverage and UX reliability checks
-- Prepare release process continuity for the next alpha tag
+- Improve article detail validation UX with required field guard and inline feedback
+- Add missing reducer safety coverage for invalid article selection paths
+- Expand Compose UI smoke tests for invalid/unsaved behaviors
+- Replace v0.2 demo placeholder with a real screen recording
+- Add v0.2 release guide and align repository documentation
 
-## Planned changes
+## Added
 
-- **README and docs sync**
-  - Align milestone checklists with actual implementation status
-  - Add explicit v0.2 planning references
-- **Demo**
-  - Add real flow recording to `docs/images/demo.gif`
-- **Testing**
-  - Extend `ArticleUiSmokeTest` for back/unsaved and invalid-selection scenarios
-- **Release**
-  - Keep `v*` tag coverage in workflow and ensure release notes availability per tag
+- Article detail validation in `ArticleDetailScreen`
+  - Title and body required checks
+  - Inline validation text for missing values
+  - Save button disabled until all validations pass
+- State safety in `ArticleListReducer`
+  - `SelectArticle` handles unknown IDs by clearing invalid selection state
+- Unit test coverage
+  - `selectArticle_invalidId_clearsSelectionForInvalidStateSafety` added in `ArticleListReducerTest`
+- Compose UI smoke test expansion
+  - Save/validation disabled behavior
+  - Back-without-save flow keeps list unchanged
+- Documentation and process updates
+  - `docs/release-guide-v0.2.0-oss-alpha.1.md` added
+  - README and roadmap/checklist text synchronized
+  - `docs/roadmap-v0.2.0.md` updated with v0.2 completion status
+
+## Release details
+
+- Release notes and guides are available for this alpha iteration
+- Android release pipeline is tag-driven through `v*` tags
+- APK is packaged as debug artifact for alpha verification (not production artifact)
+
+## Validation notes
+
+- CI check: `Android CI`
+- Manual smoke path checked on physical device for:
+  - Detail edit save path
+  - Back without saving path
+  - Required validation behavior
 
 ## Known limitations
 
-- v0.2 release artifact and optional advanced UX polish are pending until the next implementation PR.
+- v0.2.0-oss-alpha.1 is prepared for continuity; publish timing and additional UX polish remain subject to future follow-up PRs.


### PR DESCRIPTION
## Summary
- Add docs/release-guide-v0.2.0-oss-alpha.1.md for the next release checklist.
- Finalize docs/release-notes-v0.2.0-oss-alpha.1.md from draft status to concrete notes.
- Update README.md and CHANGELOG.md for v0.2 alpha preparation state.

## Changes
- docs/release-guide-v0.2.0-oss-alpha.1.md (new)
- docs/release-notes-v0.2.0-oss-alpha.1.md
- README.md
- CHANGELOG.md

## Verification
- Docs-only change: no local build/test executed.
- Existing PR#22 manual/device validation is already confirmed and recorded in PR#22 comments.\n